### PR TITLE
skills/task-implementer: add branch/PR/auto-merge landing flow

### DIFF
--- a/.beans/dotfiles-jvuy--refine-task-implementer-skill.md
+++ b/.beans/dotfiles-jvuy--refine-task-implementer-skill.md
@@ -1,0 +1,27 @@
+---
+# dotfiles-jvuy
+title: Refine task implementer skill
+status: completed
+type: task
+priority: normal
+created_at: 2026-06-06T17:32:09Z
+updated_at: 2026-06-06T17:50:25Z
+---
+
+Changes:
+
+1. A epic/feature/task each get a branch, as appropriate (e.g. - a feature may have multiple tasks that logically belong on a branch).
+2. Once done, open a PR back into `master`.
+3. Enable auto-merge once checks pass & wait for it to merge using gh CLI
+4. Once merged, switch back to master and `git fomo`, then delete the feature branch
+
+## Summary of Changes
+
+Refined the `task-implementer` skill to land work through a branch + PR + auto-merge flow:
+
+- **Step 3 (new) — Branch**: implement on a dedicated `<type>/<slug>` branch; sibling tasks under a shared parent reuse the parent's `<parent-type>/<parent-slug>` branch.
+- **Steps 4–7 renumbered** (Implement / Subagent review / User review / Mark done & commit). Commit is now made on the branch.
+- **Step 8 (new) — Open a PR and land it**: push, open a PR into `master` with a real title/body (incl. the Claude Code trailer and a `Follow-ups:` line), enable auto-merge via `gh pr merge --auto --rebase --delete-branch`, wait on `gh pr checks --watch`, then return to `master`, `git fomo`, and `git branch -D` the branch.
+- CI-failure path loops back to the Implement step (re-review if non-trivial) and prefers amending commits over stacking fix commits.
+
+Merge strategy is **rebase** (per user direction). Notable correctness fixes from review: `git branch -D` (not `-d`) since rebase/squash replays commits with new SHAs; explicit PR body instead of `--fill` to preserve the trailer convention; `--watch` non-zero exit is handled as 'fix and retry', not abort.

--- a/.claude/skills/task-implementer/SKILL.md
+++ b/.claude/skills/task-implementer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-implementer
-description: Use when asked to implement a bean, work on a bean, or pick up a task by its bean id (e.g. "implement dotfiles-4byb", "work on this bean"). Drives the full loop — read, validate, implement, subagent review, user review, then mark done and commit.
+description: Use when asked to implement a bean, work on a bean, or pick up a task by its bean id (e.g. "implement dotfiles-4byb", "work on this bean"). Drives the full loop — read, validate, branch, implement, subagent review, user review, then land via a PR with auto-merge.
 ---
 
 # Task Implementer
@@ -37,7 +37,20 @@ If everything checks out, set the bean in-progress (`beans update <id> -s in-pro
 
 **If anything is ambiguous, contradictory, blocked, or out of date — STOP.** Present the specific discrepancies to the user as a short list and ask how to resolve them. Do not guess and proceed, and do not silently "fix" the bean's intent. Resolving a discrepancy may mean editing the bean body, splitting it, or unblocking a dependency — let the user decide. Resume implementation only once the bean is coherent and unblocked.
 
-## Step 3 — Implement
+## Step 3 — Branch
+
+Implement on a dedicated branch, never directly on `master`. The branch tracks a **unit of work**, which is not always one bean:
+
+- A standalone task, or an epic/feature you are landing as a single piece, gets its own branch named `<type>/<slug>` (e.g. `task/refine-task-implementer-skill`) — use the bean's `slug` field from `beans show`.
+- When the bean is one of several sibling tasks under a parent feature/epic meant to ship together, share the parent's branch rather than cutting a per-task branch — name it `<parent-type>/<parent-slug>` from the parent bean's fields. If that branch already exists, check it out and build on it; otherwise create it.
+
+```bash
+git checkout -b <type>/<slug>   # or `git checkout <existing-branch>` to join shared work
+```
+
+If you are already on the right non-`master` branch for this unit of work, stay on it.
+
+## Step 4 — Implement
 
 Follow the bean's plan and the repo's conventions (see the root and nearest `CLAUDE.md`). Check off each todo item on the bean as you complete it, so the bean reflects real progress:
 
@@ -47,19 +60,19 @@ beans update <id> --body-replace-old "- [ ] <item>" --body-replace-new "- [x] <i
 
 Validate your work the way the repo expects — for Rust changes run `cargo test --workspace`; for a broader check run `nix flake check` (this is what CI runs). Do not move on with failing tests.
 
-## Step 4 — Subagent code review
+## Step 5 — Subagent code review
 
 Hand the change to a fresh subagent for review rather than reviewing your own work — a second context catches what the implementing one rationalizes away. Prefer the **critical-code-reviewer** skill if it is available; otherwise dispatch a general review agent. Scope the review to the diff for this bean and give the reviewer the bean's acceptance criteria so it can check intent, not just style.
 
 Triage the findings: address Blocking and Required items before landing. For Suggestions, apply the worthwhile ones and offer the rest to the user as optional follow-up beans. Re-run the repo's validation after any fixes.
 
-## Step 5 — User code review
+## Step 6 — User code review
 
 Before committing, request a review from the user — the subagent checks the code, but only the user can confirm it matches what they actually wanted. Use the **plannotator-user-code-review** skill to collect structured annotations, then address each item. Re-run the repo's validation after any changes.
 
 Treat this as a gate: do not commit until the user's review is resolved.
 
-## Step 6 — Mark done and commit
+## Step 7 — Mark done and commit
 
 Only when every todo item on the bean is checked and both reviews are resolved:
 
@@ -71,6 +84,48 @@ Only when every todo item on the bean is checked and both reviews are resolved:
    <what changed and why>"
    ```
 
-2. Commit the **code changes and the bean file together** in one commit. The bean's state and the code it describes must never drift apart. Follow the repo's commit convention (see the root `CLAUDE.md`).
+2. Commit the **code changes and the bean file together** in one commit on the branch. The bean's state and the code it describes must never drift apart. Follow the repo's commit convention (see the root `CLAUDE.md`).
 
-Commit and push only when the user has asked you to; if unsure, stage the work and confirm. After landing, offer follow-up beans for anything deferred.
+## Step 8 — Open a PR and land it
+
+Invoking this skill on a bean is the request to land it; the user review in Step 6 is the human gate, so you do not need to ask again before opening the PR.
+
+1. Push the branch and open a PR back into `master`. Write a real title and body rather than relying on `--fill`, and end the body with the repo's PR trailer convention:
+
+   ```bash
+   git push -u origin <branch>
+   gh pr create --base master --title "<area>: <summary>" --body "$(cat <<'EOF'
+   <what changed and why>
+
+   Follow-ups: <ids of any deferred follow-up beans, or "none">
+
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)
+   EOF
+   )"
+   ```
+
+2. Enable auto-merge (rebase) with branch cleanup, so the PR rebases onto `master` once required checks pass rather than holding open:
+
+   ```bash
+   gh pr merge --auto --rebase --delete-branch
+   ```
+
+   If this errors because the required checks aren't registered yet, wait a few seconds and retry — auto-merge only sticks once GitHub has queued the checks.
+
+3. Wait for the merge to actually happen, then confirm it:
+
+   ```bash
+   gh pr checks --watch        # blocks until CI resolves; non-zero exit means a check FAILED
+   gh pr view --json state,mergedAt --jq '{state, mergedAt}'
+   ```
+
+   A non-zero exit from `--watch` is not a reason to abort — it means a check failed. Identify the failure and return to **Step 4 (Implement)** to fix it; if the fix is non-trivial, run the review loop (Steps 5–6) again before pushing. Prefer amending the existing commit(s) for a CI fix over stacking new "fix CI" commits — the rebase merge replays every commit onto `master`, so keep the history clean (amending a pushed commit needs `git push --force-with-lease`). Then let auto-merge retry. If `--watch` succeeds but `state` is still `OPEN` (auto-merge can lag the checks), wait and re-check until `mergedAt` is set. Never force the merge past a red check.
+
+4. Once merged, return to `master` and sync. `--delete-branch` already removed the remote branch; delete the local one too. A rebase-merged branch is replayed with new commit SHAs, so git's safe `-d` would refuse it as "not merged" — use `-D`:
+
+   ```bash
+   git checkout master && git fomo
+   git branch -D <branch>
+   ```
+
+After landing, create follow-up beans for anything deferred (e.g. review Suggestions you chose not to apply) and link them in the PR — in the `Follow-ups:` line of the body when you open it, or as a PR comment if decided later — so the PR and its follow-ups read as one logical group of work.


### PR DESCRIPTION
Refines the `task-implementer` skill (bean dotfiles-jvuy) to land work through a branch → PR → rebase auto-merge flow:

- New **Step 3 — Branch** (dedicated `<type>/<slug>` branch; sibling tasks share the parent's branch)
- New **Step 8 — Open a PR and land it** (push, PR into `master`, `gh pr merge --auto --rebase --delete-branch`, wait on checks, then `git fomo` + `git branch -D`)
- CI-failure path loops back to Implement and prefers amending over stacking commits
- Renumbers the intervening implement/review/commit steps

Developed as a live dogfood run of the refined skill itself.

Follow-ups: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)