### PR TITLE
crates: relocate Rust build/check wiring into crates/default.nix

### DIFF
--- a/.beans/dotfiles-oqxj--extract-rust-buildcheck-wiring-from-flakenix-into.md
+++ b/.beans/dotfiles-oqxj--extract-rust-buildcheck-wiring-from-flakenix-into.md
@@ -1,36 +1,298 @@
 ---
 # dotfiles-oqxj
 title: Extract Rust build/check wiring from flake.nix into crates/
-status: todo
+status: completed
 type: task
+priority: normal
 created_at: 2026-06-06T20:22:03Z
-updated_at: 2026-06-06T20:22:03Z
+updated_at: 2026-06-06T21:10:50Z
 parent: dotfiles-ubfq
 ---
 
-Follow-up to dotfiles-u7oa (crane migration). The `dotfilesOverlay` in `flake.nix` now carries a fair amount of Rust-specific wiring: `buildToolchain`/`rustToolchain`, `craneLib`, `commonArgs` (src fileset, libiconv, cargoExtraArgs), `cargoArtifacts`, and the `rustChecks` set. This bloats the top-level flake with crate-build concerns.
+Relocate all Rust build/check wiring out of `flake.nix`'s `dotfilesOverlay` into a colocated
+`crates/default.nix`, exported as a second overlay fragment that provides a `buildLocalRustBin`
+helper. `flake.nix` ends up Rust-agnostic.
 
-## Goal
+**Spec (approved):** `docs/specs/2026-06-06-relocate-rust-wiring.md` — read it first; all design
+decisions (caller-provided `pname`/`version`, `--bin` package scoping, disjoint-key overlay
+merge) are locked there.
 
-Investigate moving the Rust-specific build/check logic out of `flake.nix` into a colocated module under `crates/` (e.g. `crates/default.nix`), so `flake.nix` just imports it and wires the results into `packages`/`checks`/`devShells`. Keep the workspace's build definition next to the workspace.
+This is one atomic refactor: `flake.nix` will not evaluate until `crates/default.nix` exists
+and `packages/beans-daemon/default.nix` matches `buildLocalRustBin`. Do all edits, then verify
+as a unit — there is no meaningful intermediate green state to commit between files.
 
-## Open questions / things to check
+**Files:**
+- Create: `crates/default.nix`
+- Modify: `flake.nix` (overlay `let`-block ~L59-134, and `defaultOverlays` ~L136-141)
+- Modify: `packages/beans-daemon/default.nix` (full rewrite)
+- Modify: `crates/CLAUDE.md` (add a note + bump freshness)
 
-- **Feasibility of the path.** The overlay derives the toolchain from `rustyPkgs.rust-bin.*` (rust-overlay applied to `prev`), and `craneLib` needs `inputs.crane` + a pkgs instance. A `crates/default.nix` would need those passed in (e.g. `import ./crates { inherit pkgs inputs; }` or via `callPackage` with extra args). Confirm the cleanest plumbing.
-- **What stays vs moves.** The devShell still needs the fat `rustToolchain` (rust-src/rust-analyzer) + `RUST_SRC_PATH`; decide whether that lives in `crates/` and is re-exported, or stays in `flake.nix`.
-- **Discovery interaction.** `packages/beans-daemon/default.nix` is auto-discovered by `discoverPackages ./packages`. If the package build moves under `crates/`, reconcile with the discovery mechanism (or keep the package thunk in `packages/` and only move the shared `craneLib`/`commonArgs`/`cargoArtifacts`/`rustChecks` derivation logic).
-- **`internal` attr.** Today the overlay exposes `dotfiles.internal.{rustToolchain,rustChecks}`. Preserve whatever the devShell/checks consume.
+---
+
+- [x] **Step 1: Create `crates/default.nix`**
+
+Move the Rust machinery here verbatim from `flake.nix`, wrapped as an overlay fragment. Note
+path literals are now relative to `crates/` so they use `../` for repo-root files.
+
+```nix
+{ inputs }:
+final: prev:
+let
+  # rust-overlay applied to `prev` so `rust-bin.*` doesn't leak into consumer
+  # pkgs and to avoid `final` recursion.
+  rustyPkgs = prev.appendOverlays [ inputs.rust-overlay.overlays.default ];
+
+  # Bare `default` profile (rustc, cargo, clippy, rustfmt) used to build packages.
+  # The `rust-src` extension lays down a `lib/rustlib/src/rust/library` tree in the
+  # toolchain store path; compiled binaries embed those source paths
+  # (panic/debuginfo metadata), so Nix's scanner records the whole toolchain as a
+  # runtime dep. Excluding `rust-src` here removes the only such reference, keeping
+  # it out of the package's runtime closure.
+  buildToolchain = rustyPkgs.rust-bin.stable.latest.default;
+  # devShell toolchain: build toolchain plus dev-only extensions.
+  rustToolchain = buildToolchain.override {
+    extensions = [
+      "rust-src"
+      "rust-analyzer"
+    ];
+  };
+
+  # crane, pinned to the bare `buildToolchain` (not the fat devShell `rustToolchain`)
+  # so dev-only extensions stay out of the package closure. `rustfmt` and `clippy`
+  # are in the `default` profile, so the fmt/clippy checks work without extra
+  # components.
+  craneLib = (inputs.crane.mkLib final).overrideToolchain buildToolchain;
+
+  # Args shared by the package build, its dependency-only artifact cache, and the
+  # clippy/test checks — so cargo deps compile once and every derivation reuses the
+  # same `cargoArtifacts`.
+  commonArgs = {
+    # Full workspace tree, not `cleanCargoSource`: `beansd` embeds non-Rust assets
+    # (askama `.html` templates compiled by the derive macro, plus `.css`/`.js`
+    # static files) that the cargo-only filter would strip. `buildDepsOnly` keys
+    # its cache off Cargo.{toml,lock} only, so including assets here doesn't churn
+    # the artifact cache.
+    src = final.lib.fileset.toSource {
+      root = ../.;
+      fileset = final.lib.fileset.unions [
+        ../Cargo.toml
+        ../Cargo.lock
+        ../crates
+      ];
+    };
+    strictDeps = true;
+    cargoExtraArgs = "--locked --workspace";
+    buildInputs = final.lib.optionals final.stdenv.isDarwin [ final.libiconv ];
+  };
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+  # Workspace-wide Rust lint/test gates surfaced as flake checks. Named `rust-*`
+  # (not `beans-daemon-*`) because `--workspace` means they cover every crate, not
+  # just the shipped package.
+  rustChecks = {
+    rust-fmt = craneLib.cargoFmt { inherit (commonArgs) src; };
+    rust-clippy = craneLib.cargoClippy (
+      commonArgs
+      // {
+        inherit cargoArtifacts;
+        cargoClippyExtraArgs = "--all-targets -- -D warnings";
+      }
+    );
+    rust-test = craneLib.cargoNextest (commonArgs // { inherit cargoArtifacts; });
+  };
+in
+{
+  # Build the named local workspace bins as one package. The package build is
+  # scoped to those bins (`--bin <name>` each); fmt/clippy/test stay `--workspace`
+  # via commonArgs, and cargoArtifacts (built `--workspace`) is a valid superset.
+  # Caller provides pname/version (these crates are never released, so version is
+  # a cosmetic default).
+  buildLocalRustBin =
+    {
+      pname,
+      bins,
+      version ? "0.1.0",
+      meta ? { },
+      ...
+    }@args:
+    craneLib.buildPackage (
+      commonArgs
+      # Forward only EXTRA crane args; pname/version/meta/bins are handled
+      # explicitly below so the `version` default actually takes effect (a
+      # defaulted arg is not present in `args`).
+      // (removeAttrs args [
+        "pname"
+        "bins"
+        "version"
+        "meta"
+      ])
+      // {
+        inherit pname version cargoArtifacts;
+        cargoExtraArgs = "--locked " + final.lib.concatMapStringsSep " " (b: "--bin ${b}") bins;
+        doCheck = false;
+        meta = {
+          mainProgram = final.lib.head bins;
+          license = final.lib.licenses.mit;
+        } // meta;
+      }
+    );
+
+  # Extend (not clobber) dotfiles.internal with the Rust output plumbing the
+  # devShell + checks read.
+  dotfiles = (prev.dotfiles or { }) // {
+    internal = (prev.dotfiles.internal or { }) // { inherit rustToolchain rustChecks; };
+  };
+}
+```
+
+- [x] **Step 2: Slim `dotfilesOverlay` in `flake.nix`**
+
+Replace the entire Rust `let`-block + `in { dotfiles = ... internal = {...}; }` (current
+~L59-134) with a discovery-only overlay. Delete `buildToolchain`/`rustToolchain`/`craneLib`/
+`commonArgs`/`cargoArtifacts`/`packageArgs`/`rustChecks` from `flake.nix`.
+
+```nix
+      dotfilesOverlay = final: prev: {
+        dotfiles = (prev.dotfiles or { }) // (
+          builtins.mapAttrs (_name: path: final.callPackage path { }) packagePaths
+        );
+      };
+```
+
+(`callPackage` auto-fills `buildLocalRustBin` for `beans-daemon` because it is a top-level
+`pkgs` attr; its built-in `intersectAttrs` passes it only to packages that declare it, so the
+other four discovered packages are untouched and need no `packageArgs`.)
+
+- [x] **Step 3: Append the crates overlay to `defaultOverlays`**
+
+```nix
+      defaultOverlays = [
+        inputs.alacritty-themes.overlays.default
+        inputs.claude-code.overlays.default
+        inputs.sprites-cli.overlays.default
+        dotfilesOverlay
+        (import ./crates { inherit inputs; })
+      ];
+```
+
+Leave `devShells`, `packages`, `checks`, and `mkPackages` exactly as they are — they still read
+`pkgs.dotfiles.internal.rustToolchain`, `pkgs.dotfiles.internal.rustChecks`, and
+`pkgs.dotfiles.<pkg>`.
+
+- [x] **Step 4: Rewrite `packages/beans-daemon/default.nix`**
+
+```nix
+{ buildLocalRustBin }:
+buildLocalRustBin {
+  pname = "beans-daemon";
+  version = "0.1.0";
+  bins = [
+    "beansd"
+    "beansctl"
+  ];
+  meta.description = "Background daemon (beansd) and control CLI (beansctl) for the beans issue tracker";
+}
+```
+
+- [x] **Step 5: Format the Nix files**
+
+Run: `nixfmt flake.nix crates/default.nix packages/beans-daemon/default.nix`
+Expected: no errors (parses clean).
+
+- [x] **Step 6: Verify `nix flake check` is green**
+
+Run: `nix flake check --print-build-logs`
+Expected: green. The `beans-daemon` package + `rust-fmt`/`rust-clippy`/`rust-test` checks all
+build/pass. (On aarch64-darwin locally; CI covers x86_64-linux.)
+
+- [x] **Step 7: Verify outputs unchanged in `nix flake show`**
+
+Run: `nix flake show`
+Expected: `packages.<sys>` still lists `beans-daemon`, `beans`, `codex`, `cship`, `plannotator`;
+`checks.<sys>` still lists `rust-fmt`, `rust-clippy`, `rust-test` (+ the packages).
+
+- [x] **Step 8: Verify closure unchanged + both binaries present**
+
+```bash
+OUT=$(nix build .#beans-daemon --no-link --print-out-paths)
+nix path-info -Sh "$OUT"                      # expect ~51 MiB
+nix-store -q --references "$OUT"              # expect libiconv ONLY (no rust-* toolchain)
+ls "$OUT/bin"                                 # expect both: beansd  beansctl
+```
+Expected: closure ~51 MiB, single `libiconv` reference, both `beansd` and `beansctl` in
+`$out/bin`. (The references check proves `buildLocalRustBin` still pins the bare
+`buildToolchain`; the `ls` proves the `--bin` scoping built both binaries.)
+
+- [x] **Step 9: Verify devShell unaffected**
+
+```bash
+RTPATH=$(nix eval --raw .#devShells.aarch64-darwin.default.RUST_SRC_PATH)
+test -d "$RTPATH" && echo "rust-src OK"
+```
+Expected: `RUST_SRC_PATH` resolves to an existing dir (devShell still gets the fat
+`rustToolchain`).
+
+- [x] **Step 10: Confirm `flake.nix` is Rust-agnostic**
+
+Run: `grep -nE 'crane|craneLib|commonArgs|cargoArtifacts|buildToolchain|rustPlatform' flake.nix`
+Expected: no matches. (Only `dotfiles.internal.rustToolchain` / `internal.rustChecks` opaque
+reads remain in the devShell/checks output blocks — those are output plumbing, acceptable.)
+
+- [x] **Step 11: Update `crates/CLAUDE.md`**
+
+Add a short note (near Purpose/Boundaries) that the workspace's Nix build + check wiring lives
+in `crates/default.nix` — an overlay fragment exporting `buildLocalRustBin` (used by
+`packages/beans-daemon/default.nix`) and the `rust-*` checks. Bump the `Freshness:` date to the
+day of implementation. Do not change the documented check names (they are unchanged).
+
+- [x] **Step 12: Commit**
+
+```bash
+git add flake.nix crates/default.nix packages/beans-daemon/default.nix crates/CLAUDE.md .beans/
+git commit -m "crates: relocate Rust build/check wiring into crates/default.nix
+
+Move the toolchain split, crane lib, commonArgs, cargoArtifacts, and the
+rust-* checks out of flake.nix's overlay into a colocated crates/default.nix
+overlay fragment exporting a buildLocalRustBin helper. flake.nix is now
+Rust-agnostic. Pure relocation; the only build-invocation change is scoping
+the package to --bin beansd --bin beansctl (output-equivalent).
+
+Bean: dotfiles-oqxj"
+```
+
+---
 
 ## Acceptance
 
-- `flake.nix` no longer holds crate-specific build details (toolchain split, crane lib, commonArgs, cargoArtifacts, rustChecks) — they live under `crates/`.
-- `nix flake check` still green; package closure unchanged (~51 MiB, libiconv only); the `rust-fmt`/`rust-clippy`/`rust-test` checks and `beans-daemon` package still present in `nix flake show`.
-- devShell still exposes the fat toolchain + `RUST_SRC_PATH`.
+- `nix flake check` green (darwin local + linux CI).
+- `nix flake show` outputs unchanged (5 packages, 3 `rust-*` checks).
+- `beans-daemon` closure ~51 MiB, `libiconv`-only runtime ref; both binaries installed.
+- devShell `RUST_SRC_PATH` valid.
+- `flake.nix` has no crane/toolchain build references.
 
-## Out of Scope
+## Notes / fallback
 
-- Behavioral changes to the build/checks — this is a pure relocation/refactor.
+- If the disjoint-key overlay merge misbehaves at eval, fall back to a fixed overlay order with
+  `lib.recursiveUpdate` for `dotfiles`.
+- If relocation proves uglier than it's worth (e.g. `final`/`prev` plumbing), it is acceptable
+  to scrap with a recorded rationale per the original bean.
 
-## Notes
+## Summary of Changes
 
-If relocation proves awkward (e.g. overlay `final`/`prev` plumbing makes it uglier than it's worth), it's acceptable to scrap with a recorded rationale rather than force it.
+Relocated all Rust build/check wiring out of `flake.nix` into a new `crates/default.nix` overlay fragment. `flake.nix` is now Rust-build-agnostic (only the `crane` *input* declaration remains, which must live there).
+
+- **New `crates/default.nix`** (`{ inputs }: final: prev: { ... }`): holds the toolchain split (`buildToolchain`/`rustToolchain`), `craneLib`, `commonArgs`, `cargoArtifacts`, and the `rust-*` checks. Exports `buildLocalRustBin { pname, bins, version ? "0.1.0", meta ? {}, ... }` (scopes the package build to `--bin <name>` per bin; checks stay `--workspace`) and `dotfiles.internal.{rustToolchain,rustChecks}`.
+- **`flake.nix`**: `dotfilesOverlay` slimmed to discovery only; `(import ./crates { inherit inputs; })` appended to `defaultOverlays`. `devShells`/`packages`/`checks` output blocks unchanged.
+- **`packages/beans-daemon/default.nix`**: collapsed to `{ buildLocalRustBin }: buildLocalRustBin { pname; version; bins = [ "beansd" "beansctl" ]; meta.description; }`.
+- **`crates/CLAUDE.md`**: documents `crates/default.nix` as the build/check home; Commands + Boundaries updated for `--bin` scoping.
+- **Spec**: `docs/specs/2026-06-06-relocate-rust-wiring.md`.
+
+### Deviation from spec
+The spec's order-independent disjoint-key overlay merge didn't survive: **nixpkgs already has a `dotfiles` attribute** (a Python tool), so `(prev.dotfiles or {})` in the discovery overlay inherited that derivation's attrs (surfaced as `packages.<sys>.outPath is not a derivation`). Fixed by having `dotfilesOverlay` do a **plain assignment** (deliberately shadowing nixpkgs' `dotfiles`, as the original code did), with only the `crates` overlay merging `prev.dotfiles`. This makes the `dotfilesOverlay`-then-`crates` order **required** — guaranteed by `defaultOverlays` list position.
+
+### Verified (aarch64-darwin; linux via eval + CI)
+- `nix flake check` green (89 tests via nextest, clippy/fmt pass).
+- `nix flake show`: 5 packages + `rust-fmt`/`rust-clippy`/`rust-test`.
+- `beans-daemon` closure 51.4 MiB, runtime ref `libiconv` only; both `beansd` + `beansctl` installed.
+- devShell `RUST_SRC_PATH` valid.
+- Subagent review: 1 Required (stale `--workspace` doc line) fixed; overlay-header comment added. User review: no changes.

--- a/crates/CLAUDE.md
+++ b/crates/CLAUDE.md
@@ -6,9 +6,14 @@ Freshness: 2026-06-06
 
 Cargo workspace housing the `beans` issue tracker referenced throughout this repo:
 a daemon, its control CLI, and a shared RPC library. Built and shipped via Nix
-(`packages/beans-daemon/default.nix`, using [crane](https://github.com/ipetkov/crane));
-CI runs `nix flake check`, which formats, lints, builds, and tests the whole
-workspace (see Commands).
+using [crane](https://github.com/ipetkov/crane); CI runs `nix flake check`, which
+formats, lints, builds, and tests the whole workspace (see Commands).
+
+The Nix build/check wiring lives in `crates/default.nix` — an overlay fragment
+(kept out of `flake.nix` so the flake stays Rust-agnostic) that holds the toolchain
+split, crane lib, shared `cargoArtifacts`, and the `rust-*` checks, and exports a
+`buildLocalRustBin { pname; bins; ... }` helper. `packages/beans-daemon/default.nix`
+is a one-liner over that helper.
 
 ## Workspace Layout
 
@@ -32,7 +37,7 @@ workspace (see Commands).
 - `cargo test -p <crate>` — single crate.
 - `nix flake check` — what CI runs (`.github/workflows/ci.yml`). Via crane, it runs
   the full loop as separate flake checks, sharing one `cargoArtifacts` deps build:
-  - `beans-daemon` — `cargo build --workspace` (the shipped package; `doCheck = false`)
+  - `beans-daemon` — `cargo build --bin beansd --bin beansctl` (the shipped package; `doCheck = false`)
   - `rust-fmt` — `cargo fmt --check`
   - `rust-clippy` — `cargo clippy --workspace --all-targets -- -D warnings`
   - `rust-test` — `cargo nextest run --workspace`
@@ -88,8 +93,9 @@ never pass `--dev`, so they're untouched.
 
 ## Boundaries
 
-- The Nix build (`packages/beans-daemon/default.nix`) builds the whole workspace
-  (`--workspace`, set via `commonArgs.cargoExtraArgs` in `flake.nix`). Adding a
-  new crate that shouldn't ship in the package means scoping that down.
+- The Nix package (`packages/beans-daemon/default.nix`) is scoped to the named bins
+  it passes to `buildLocalRustBin` (`--bin beansd --bin beansctl`). The fmt/clippy/test
+  checks and the shared `cargoArtifacts` stay `--workspace` (see `crates/default.nix`).
+  A new shipped binary means adding it to that `bins` list.
 - Check `[workspace.dependencies]` before adding a dep to a single crate's
   `Cargo.toml` — prefer inheriting over re-pinning.

--- a/crates/default.nix
+++ b/crates/default.nix
@@ -1,0 +1,114 @@
+# A nixpkgs overlay fragment (not a buildable package) holding the Rust build +
+# check wiring for the workspace. Imported into `flake.nix`'s `defaultOverlays`;
+# exports the `buildLocalRustBin` helper and `dotfiles.internal.{rustToolchain,rustChecks}`.
+{ inputs }:
+final: prev:
+let
+  # rust-overlay applied to `prev` so `rust-bin.*` doesn't leak into consumer
+  # pkgs and to avoid `final` recursion.
+  rustyPkgs = prev.appendOverlays [ inputs.rust-overlay.overlays.default ];
+
+  # Bare `default` profile (rustc, cargo, clippy, rustfmt) used to build packages.
+  # The `rust-src` extension lays down a `lib/rustlib/src/rust/library` tree in the
+  # toolchain store path; compiled binaries embed those source paths
+  # (panic/debuginfo metadata), so Nix's scanner records the whole toolchain as a
+  # runtime dep. Excluding `rust-src` here removes the only such reference, keeping
+  # it out of the package's runtime closure.
+  buildToolchain = rustyPkgs.rust-bin.stable.latest.default;
+  # devShell toolchain: build toolchain plus dev-only extensions.
+  rustToolchain = buildToolchain.override {
+    extensions = [
+      "rust-src"
+      "rust-analyzer"
+    ];
+  };
+
+  # crane, pinned to the bare `buildToolchain` (not the fat devShell `rustToolchain`)
+  # so dev-only extensions stay out of the package closure. `rustfmt` and `clippy`
+  # are in the `default` profile, so the fmt/clippy checks work without extra
+  # components.
+  craneLib = (inputs.crane.mkLib final).overrideToolchain buildToolchain;
+
+  # Args shared by the package build, its dependency-only artifact cache, and the
+  # clippy/test checks — so cargo deps compile once and every derivation reuses the
+  # same `cargoArtifacts`.
+  commonArgs = {
+    # Full workspace tree, not `cleanCargoSource`: `beansd` embeds non-Rust assets
+    # (askama `.html` templates compiled by the derive macro, plus `.css`/`.js`
+    # static files) that the cargo-only filter would strip. `buildDepsOnly` keys
+    # its cache off Cargo.{toml,lock} only, so including assets here doesn't churn
+    # the artifact cache.
+    src = final.lib.fileset.toSource {
+      root = ../.;
+      fileset = final.lib.fileset.unions [
+        ../Cargo.toml
+        ../Cargo.lock
+        ../crates
+      ];
+    };
+    strictDeps = true;
+    cargoExtraArgs = "--locked --workspace";
+    buildInputs = final.lib.optionals final.stdenv.isDarwin [ final.libiconv ];
+  };
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+  # Workspace-wide Rust lint/test gates surfaced as flake checks. Named `rust-*`
+  # (not `beans-daemon-*`) because `--workspace` means they cover every crate, not
+  # just the shipped package.
+  rustChecks = {
+    rust-fmt = craneLib.cargoFmt { inherit (commonArgs) src; };
+    rust-clippy = craneLib.cargoClippy (
+      commonArgs
+      // {
+        inherit cargoArtifacts;
+        cargoClippyExtraArgs = "--all-targets -- -D warnings";
+      }
+    );
+    rust-test = craneLib.cargoNextest (commonArgs // { inherit cargoArtifacts; });
+  };
+in
+{
+  # Build the named local workspace bins as one package. The package build is
+  # scoped to those bins (`--bin <name>` each); fmt/clippy/test stay `--workspace`
+  # via commonArgs, and cargoArtifacts (built `--workspace`) is a valid superset.
+  # Caller provides pname/version (these crates are never released, so version is
+  # a cosmetic default).
+  buildLocalRustBin =
+    {
+      pname,
+      bins,
+      version ? "0.1.0",
+      meta ? { },
+      ...
+    }@args:
+    craneLib.buildPackage (
+      commonArgs
+      # Forward only EXTRA crane args; pname/version/meta/bins are handled
+      # explicitly below so the `version` default actually takes effect (a
+      # defaulted arg is not present in `args`).
+      // (removeAttrs args [
+        "pname"
+        "bins"
+        "version"
+        "meta"
+      ])
+      // {
+        inherit pname version cargoArtifacts;
+        cargoExtraArgs = "--locked " + final.lib.concatMapStringsSep " " (b: "--bin ${b}") bins;
+        doCheck = false;
+        meta = {
+          mainProgram = final.lib.head bins;
+          license = final.lib.licenses.mit;
+        }
+        // meta;
+      }
+    );
+
+  # Extend (not clobber) dotfiles.internal with the Rust output plumbing the
+  # devShell + checks read.
+  dotfiles = (prev.dotfiles or { }) // {
+    internal = (prev.dotfiles.internal or { }) // {
+      inherit rustToolchain rustChecks;
+    };
+  };
+}

--- a/docs/specs/2026-06-06-relocate-rust-wiring.md
+++ b/docs/specs/2026-06-06-relocate-rust-wiring.md
@@ -1,0 +1,211 @@
+# Spec: Relocate Rust build/check wiring into `crates/default.nix`
+
+**Bean:** dotfiles-oqxj (parent epic: dotfiles-ubfq, Rust build improvements)
+**Date:** 2026-06-06
+
+## Goal
+
+`flake.nix` should read as Rust-agnostic system/host wiring. Move all crate-build detail
+(toolchain split, crane, `commonArgs`, `cargoArtifacts`, the fmt/clippy/test checks) into a
+colocated module at `crates/default.nix`, exported as a second overlay fragment. The
+`beans-daemon` package collapses to a call over a `buildLocalRustBin` helper.
+
+This is a **relocation refactor**. The flake *outputs* are identical before and after (same
+package binaries, same checks, same devShell). The one intentional build-invocation change is
+scoping the `beans-daemon` package build from `--workspace` to `--bin beansd --bin beansctl`
+— output-equivalent (both binaries still produced) but a real change in what cargo compiles
+for the package. The fmt/clippy/test checks stay `--workspace`, and `cargoArtifacts` is still
+built `--workspace` (a valid superset). No change to the daemon's runtime behavior.
+
+## Background: current state (master)
+
+All Rust wiring lives inside `dotfilesOverlay` in `flake.nix`:
+
+- `rustyPkgs = prev.appendOverlays [ inputs.rust-overlay.overlays.default ]` (uses `prev` to
+  avoid leaking `rust-bin.*` and to avoid `final` recursion).
+- `buildToolchain` — bare `rust-bin.stable.latest.default` (rustc/cargo/clippy/rustfmt).
+- `rustToolchain` — `buildToolchain.override { extensions = [ "rust-src" "rust-analyzer" ]; }`
+  (devShell only).
+- `craneLib = (inputs.crane.mkLib final).overrideToolchain buildToolchain`.
+- `commonArgs = { src = <fileset Cargo.toml+Cargo.lock+crates>; strictDeps = true;
+  cargoExtraArgs = "--locked --workspace"; buildInputs = lib.optionals stdenv.isDarwin [ libiconv ]; }`.
+- `cargoArtifacts = craneLib.buildDepsOnly commonArgs`.
+- `packageArgs.beans-daemon = { inherit craneLib commonArgs cargoArtifacts; }` — fed into the
+  auto-discovered package via `discoverPackages ./packages` + `final.callPackage`.
+- `rustChecks = { rust-fmt = craneLib.cargoFmt {...}; rust-clippy = craneLib.cargoClippy {...};
+  rust-test = craneLib.cargoNextest {...}; }`.
+- Exposed as `dotfiles.internal.{ rustToolchain, rustChecks }`.
+
+`packages/beans-daemon/default.nix` is currently
+`{ lib, craneLib, commonArgs, cargoArtifacts }: craneLib.buildPackage (commonArgs // { pname; version; ... doCheck = false; meta; })`.
+
+Consumers in `flake.nix` outputs:
+- `devShells` → `pkgs.dotfiles.internal.rustToolchain` + `RUST_SRC_PATH`.
+- `packages.<sys>` → `mkPackages pkgs = removeAttrs pkgs.dotfiles [ "internal" ]`.
+- `checks.<sys>` → `self.packages.<sys> // pkgs.dotfiles.internal.rustChecks`.
+
+`packages/` has 5 discovered packages; only `beans-daemon` is Rust. The other four (`beans`,
+`codex`, `cship`, `plannotator`) are non-Rust and must remain untouched.
+
+## Design
+
+### 1. New module: `crates/default.nix` (overlay fragment)
+
+A function of `{ inputs }` returning an overlay (`final: prev: { ... }`):
+
+```nix
+{ inputs }:
+final: prev:
+let
+  rustyPkgs = prev.appendOverlays [ inputs.rust-overlay.overlays.default ];
+
+  buildToolchain = rustyPkgs.rust-bin.stable.latest.default;
+  rustToolchain = buildToolchain.override {
+    extensions = [ "rust-src" "rust-analyzer" ];
+  };
+
+  craneLib = (inputs.crane.mkLib final).overrideToolchain buildToolchain;
+
+  commonArgs = {
+    src = final.lib.fileset.toSource {
+      root = ../.;                       # repo root, relative to crates/default.nix
+      fileset = final.lib.fileset.unions [
+        ../Cargo.toml
+        ../Cargo.lock
+        ../crates
+      ];
+    };
+    strictDeps = true;
+    cargoExtraArgs = "--locked --workspace";
+    buildInputs = final.lib.optionals final.stdenv.isDarwin [ final.libiconv ];
+  };
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+  rustChecks = {
+    rust-fmt = craneLib.cargoFmt { inherit (commonArgs) src; };
+    rust-clippy = craneLib.cargoClippy (
+      commonArgs // { inherit cargoArtifacts; cargoClippyExtraArgs = "--all-targets -- -D warnings"; }
+    );
+    rust-test = craneLib.cargoNextest (commonArgs // { inherit cargoArtifacts; });
+  };
+in
+{
+  # Builder helper: build the named local workspace bins as one package. The
+  # package build is scoped to those bins (`--bin <name>` each); fmt/clippy/test
+  # stay `--workspace` via commonArgs. Caller provides pname/version (these crates
+  # are never released, so version is a cosmetic default).
+  buildLocalRustBin =
+    { pname, bins, version ? "0.1.0", meta ? { }, ... }@args:
+    craneLib.buildPackage (
+      commonArgs
+      # Forward only EXTRA crane args; pname/version/meta/bins are handled
+      # explicitly below so the `version` default actually takes effect (a
+      # defaulted arg is not present in `args`).
+      // (removeAttrs args [ "pname" "bins" "version" "meta" ])
+      // {
+        inherit pname version cargoArtifacts;
+        cargoExtraArgs = "--locked " + final.lib.concatMapStringsSep " " (b: "--bin ${b}") bins;
+        doCheck = false;
+        meta = { mainProgram = final.lib.head bins; license = final.lib.licenses.mit; } // meta;
+      }
+    );
+
+  # Extend (not clobber) dotfiles.internal with the Rust output plumbing.
+  dotfiles = (prev.dotfiles or { }) // {
+    internal = (prev.dotfiles.internal or { }) // { inherit rustToolchain rustChecks; };
+  };
+}
+```
+
+Notes:
+- Path literals (`../Cargo.toml`, etc.) are resolved relative to `crates/default.nix`, i.e.
+  repo root — equivalent to today's `./Cargo.toml` in `flake.nix`.
+- `removeAttrs args [ "bins" "meta" ]` forwards `pname`/`version`/any extra crane args
+  through, while `bins`/`meta` are handled explicitly (so they aren't passed twice).
+- `version` defaults to `"0.1.0"`; callers may still pass it explicitly.
+
+### 2. `flake.nix` changes
+
+- **Delete** the entire Rust `let`-block from `dotfilesOverlay` (`buildToolchain`,
+  `rustToolchain`, `craneLib`, `commonArgs`, `cargoArtifacts`, `packageArgs`, `rustChecks`)
+  and the `internal = { inherit rustToolchain rustChecks; }` it produced.
+- `dotfilesOverlay` shrinks to the discovery + merge only:
+  ```nix
+  dotfilesOverlay = final: prev: {
+    dotfiles = (prev.dotfiles or { }) // (
+      builtins.mapAttrs (name: path: final.callPackage path { }) packagePaths
+    );
+  };
+  ```
+  (No more `packageArgs`; `callPackage` auto-fills `buildLocalRustBin` for `beans-daemon`
+  because it is a top-level `pkgs` attr, and `callPackage`'s built-in `intersectAttrs`
+  passes it *only* to packages that declare it — the other four are unaffected.)
+- Append the crates overlay to `defaultOverlays`:
+  ```nix
+  defaultOverlays = [
+    inputs.alacritty-themes.overlays.default
+    inputs.claude-code.overlays.default
+    inputs.sprites-cli.overlays.default
+    dotfilesOverlay
+    (import ./crates { inherit inputs; })
+  ];
+  ```
+- **Order-independence:** the two fragments own disjoint keys under `dotfiles` (discovery
+  writes package-name keys; crates writes `dotfiles.internal`) and each merges
+  `prev.dotfiles or { }`, so neither clobbers the other regardless of list order. `beans-daemon`
+  resolves `buildLocalRustBin` from `final`, so it is present no matter the order.
+- `devShells`, `packages`, `checks`, `mkPackages` output blocks are **unchanged**.
+
+### 3. `packages/beans-daemon/default.nix`
+
+Collapses to:
+
+```nix
+{ buildLocalRustBin }:
+buildLocalRustBin {
+  pname = "beans-daemon";
+  version = "0.1.0";
+  bins = [ "beansd" "beansctl" ];
+  meta.description = "Background daemon (beansd) and control CLI (beansctl) for the beans issue tracker";
+}
+```
+
+### 4. `crates/CLAUDE.md`
+
+Add a short note that the workspace's Nix build/check wiring lives in `crates/default.nix`
+(exporting `buildLocalRustBin` + the `rust-*` checks via an overlay), and bump the freshness
+date. Keep the existing Commands section accurate (the four checks already documented there
+do not change).
+
+## Validation / acceptance
+
+Run on aarch64-darwin locally; CI covers x86_64-linux.
+
+1. `nix flake check` is green.
+2. `nix flake show` still lists `packages.<sys>.beans-daemon` (+ `beans`, `codex`, `cship`,
+   `plannotator`) and `checks.<sys>.{ rust-fmt, rust-clippy, rust-test }`.
+3. `beans-daemon` closure is still ~51 MiB and `nix-store -q --references` shows `libiconv`
+   only (no `rust-*` toolchain) — confirms `buildLocalRustBin` still pins `buildToolchain`.
+4. Both `beansd` and `beansctl` are present in `$out/bin` — guards the `--bin` scoping change.
+5. devShell still exposes a valid `RUST_SRC_PATH` and `rust-analyzer` on `PATH`.
+6. `flake.nix` contains no `crane`/`craneLib`/`commonArgs`/`cargoArtifacts`/toolchain
+   references (only the opaque `dotfiles.internal.{rustToolchain,rustChecks}` reads in the
+   devShell/checks output blocks remain).
+
+## Risks
+
+- **`--bin` scoping:** relies on `beansd`/`beansctl` being unique bin names across the
+  workspace (they are). Check (4) catches any regression.
+- **Overlay merge:** the disjoint-key merge is caught at eval time if wrong; fallback is an
+  explicit overlay order + `lib.recursiveUpdate`.
+- **`crateNameFromCargoToml` not used:** version is caller-provided/defaulted, sidestepping
+  workspace-inherited-version detection issues.
+
+## Out of scope
+
+- Behavioral changes beyond the deliberate `--bin` package scoping noted above (no toolchain
+  bump, no check-flag changes, no `clippy.toml`/`[workspace.lints]`).
+- Dependency caching on CI (separate future bean).
+- Touching the other four discovered packages.
+- Generalizing `buildLocalRustBin` beyond what `beans-daemon` needs (no second Rust package
+  exists yet).

--- a/flake.nix
+++ b/flake.nix
@@ -54,90 +54,22 @@
 
       packagePaths = discoverPackages ./packages;
 
-      # rust-overlay is applied to `prev` here so `rust-bin.*` doesn't leak
-      # into consumer pkgs via `defaultOverlays`.
-      dotfilesOverlay =
-        final: prev:
-        let
-          rustyPkgs = prev.appendOverlays [ inputs.rust-overlay.overlays.default ];
-          # Bare `default` profile (rustc, cargo, clippy, rustfmt) used to build
-          # packages. The `rust-src` extension lays down a `lib/rustlib/src/rust/library`
-          # tree in the toolchain store path; compiled binaries embed those source
-          # paths (panic/debuginfo metadata), so Nix's scanner records the whole
-          # toolchain as a runtime dep. Excluding `rust-src` here removes the only
-          # such reference, keeping it out of the package's runtime closure.
-          buildToolchain = rustyPkgs.rust-bin.stable.latest.default;
-          # devShell toolchain: build toolchain plus dev-only extensions.
-          rustToolchain = buildToolchain.override {
-            extensions = [
-              "rust-src"
-              "rust-analyzer"
-            ];
-          };
-
-          # crane, pinned to the bare `buildToolchain` (not the fat devShell
-          # `rustToolchain`) so dev-only extensions stay out of the package
-          # closure. `rustfmt` and `clippy` are in the `default` profile, so the
-          # fmt/clippy checks work without extra components.
-          craneLib = (inputs.crane.mkLib final).overrideToolchain buildToolchain;
-          # Args shared by the package build, its dependency-only artifact cache,
-          # and the clippy/test checks — so cargo deps compile once and every
-          # derivation reuses the same `cargoArtifacts`.
-          commonArgs = {
-            # Full workspace tree, not `cleanCargoSource`: `beansd` embeds
-            # non-Rust assets (askama `.html` templates compiled by the derive
-            # macro, plus `.css`/`.js` static files) that the cargo-only filter
-            # would strip. `buildDepsOnly` keys its cache off Cargo.{toml,lock}
-            # only, so including assets here doesn't churn the artifact cache.
-            src = final.lib.fileset.toSource {
-              root = ./.;
-              fileset = final.lib.fileset.unions [
-                ./Cargo.toml
-                ./Cargo.lock
-                ./crates
-              ];
-            };
-            strictDeps = true;
-            cargoExtraArgs = "--locked --workspace";
-            buildInputs = final.lib.optionals final.stdenv.isDarwin [ final.libiconv ];
-          };
-          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-
-          packageArgs = {
-            beans-daemon = { inherit craneLib commonArgs cargoArtifacts; };
-          };
-          packages = builtins.mapAttrs (
-            name: path: final.callPackage path (packageArgs.${name} or { })
-          ) packagePaths;
-
-          # Workspace-wide Rust lint/test gates surfaced as flake checks. Named
-          # `rust-*` (not `beans-daemon-*`) because `--workspace` means they
-          # cover every crate, not just the shipped package. Wired into
-          # `checks.<system>` below so `nix flake check` runs fmt → clippy → test
-          # alongside the package build, sharing `cargoArtifacts`.
-          rustChecks = {
-            rust-fmt = craneLib.cargoFmt { inherit (commonArgs) src; };
-            rust-clippy = craneLib.cargoClippy (
-              commonArgs
-              // {
-                inherit cargoArtifacts;
-                cargoClippyExtraArgs = "--all-targets -- -D warnings";
-              }
-            );
-            rust-test = craneLib.cargoNextest (commonArgs // { inherit cargoArtifacts; });
-          };
-        in
-        {
-          dotfiles = packages // {
-            internal = { inherit rustToolchain rustChecks; };
-          };
-        };
+      # Discovers and builds the packages under ./packages. Plain assignment, not
+      # a merge with `prev` — `dotfiles` deliberately shadows nixpkgs' own
+      # `dotfiles` attribute (a Python tool) with our package set. The `crates`
+      # overlay (applied after this one) extends the result with
+      # `internal.{rustToolchain,rustChecks}`, and `callPackage` auto-fills the
+      # `buildLocalRustBin` helper it exports for the package that declares it.
+      dotfilesOverlay = final: _prev: {
+        dotfiles = builtins.mapAttrs (_name: path: final.callPackage path { }) packagePaths;
+      };
 
       defaultOverlays = [
         inputs.alacritty-themes.overlays.default
         inputs.claude-code.overlays.default
         inputs.sprites-cli.overlays.default
         dotfilesOverlay
+        (import ./crates { inherit inputs; })
       ];
 
       nixOsPkgs =

--- a/packages/beans-daemon/default.nix
+++ b/packages/beans-daemon/default.nix
@@ -1,28 +1,10 @@
-{
-  lib,
-  craneLib,
-  commonArgs,
-  cargoArtifacts,
-}:
-craneLib.buildPackage (
-  commonArgs
-  // {
-    pname = "beans-daemon";
-    version = "0.1.0";
-    inherit cargoArtifacts;
-    # Builds all workspace members: `beansd` (daemon binary, mainProgram) and
-    # `beansctl` (control CLI used by the chpwd hook and direct invocation).
-    # Both binaries are installed to $out/bin. `--workspace` comes from
-    # `commonArgs.cargoExtraArgs`.
-    #
-    # Tests run as a dedicated `beans-daemon-test` flake check, so skip them in
-    # the package build to keep it lean (deps are already cached via
-    # cargoArtifacts).
-    doCheck = false;
-    meta = with lib; {
-      description = "Background daemon (beansd) and control CLI (beansctl) for the beans issue tracker";
-      mainProgram = "beansd";
-      license = licenses.mit;
-    };
-  }
-)
+{ buildLocalRustBin }:
+buildLocalRustBin {
+  pname = "beans-daemon";
+  version = "0.1.0";
+  bins = [
+    "beansd"
+    "beansctl"
+  ];
+  meta.description = "Background daemon (beansd) and control CLI (beansctl) for the beans issue tracker";
+}


### PR DESCRIPTION
Relocates all Rust build/check wiring out of `flake.nix` into a colocated `crates/default.nix` overlay fragment, so `flake.nix` reads as Rust-agnostic system wiring. (Follow-up to the crane migration; bean dotfiles-oqxj under the Rust-build-improvements epic.)

## What changed
- **New `crates/default.nix`** — `{ inputs }: final: prev: { ... }` overlay fragment holding the toolchain split, `craneLib`, `commonArgs`, `cargoArtifacts`, and the `rust-*` checks. Exports:
  - `buildLocalRustBin { pname, bins, version ? "0.1.0", meta ? {}, ... }` — builds the named workspace bins as one package (`--bin <name>` each); fmt/clippy/test + the shared `cargoArtifacts` stay `--workspace`.
  - `dotfiles.internal.{ rustToolchain, rustChecks }`.
- **`flake.nix`** — `dotfilesOverlay` slimmed to package discovery; `(import ./crates { inherit inputs; })` appended to `defaultOverlays`. No `craneLib`/`commonArgs`/`cargoArtifacts`/`buildToolchain` left (only the `crane` input declaration). `devShells`/`packages`/`checks` blocks untouched.
- **`packages/beans-daemon/default.nix`** — collapses to `{ buildLocalRustBin }: buildLocalRustBin { pname; version; bins = [ "beansd" "beansctl" ]; meta.description; }`.
- **`crates/CLAUDE.md`** — documents the new build/check home; Commands + Boundaries updated for `--bin` scoping.
- Approved design spec at `docs/specs/2026-06-06-relocate-rust-wiring.md`.

## Note on the overlay merge (deviation from the spec)
The spec proposed an order-independent disjoint-key merge. In practice **nixpkgs already has a `dotfiles` attribute** (a Python tool), so merging `(prev.dotfiles or {})` in the discovery overlay inherited that derivation's attrs (`packages.<sys>.outPath is not a derivation`). Fixed by having `dotfilesOverlay` do a plain `dotfiles =` assignment (deliberately shadowing nixpkgs', as the original code did); only the `crates` overlay merges `prev.dotfiles`. This makes the `dotfilesOverlay`→`crates` order required, guaranteed by `defaultOverlays` list position.

## Verification
- `nix flake check` green on aarch64-darwin (89 tests via nextest); x86_64-linux verified by eval + CI.
- `nix flake show`: 5 packages + `rust-fmt`/`rust-clippy`/`rust-test`.
- `beans-daemon` closure still 51.4 MiB, runtime ref `libiconv` only; both `beansd` + `beansctl` installed.
- devShell `RUST_SRC_PATH` valid.

Follow-ups: dotfiles-aubb (apply the same nixfmt-on-`nix flake check` treatment for Nix) — still open on the epic.

Bean: dotfiles-oqxj

🤖 Generated with [Claude Code](https://claude.com/claude-code)