### PR TITLE
home/programs/codex: install bubblewrap on Linux

### DIFF
--- a/.beans/dotfiles-040q--install-bubblewrap-with-codex-on-linux.md
+++ b/.beans/dotfiles-040q--install-bubblewrap-with-codex-on-linux.md
@@ -1,0 +1,18 @@
+---
+# dotfiles-040q
+title: Install bubblewrap with codex on Linux
+status: completed
+type: task
+priority: normal
+created_at: 2026-06-11T10:18:01Z
+updated_at: 2026-06-11T10:19:24Z
+---
+
+Codex looks for the bwrap sandbox on Linux. The codex home-manager module should ensure nixpkgs.bubblewrap is available on PATH (like rg) when codex is enabled on Linux.
+
+- [x] Add pkgs.bubblewrap to home.packages on Linux in home/programs/codex/default.nix
+- [x] Validate with nix flake check / build
+
+## Summary of Changes
+
+Added `home.packages = lib.optionals pkgs.stdenv.isLinux [ pkgs.bubblewrap ]` to `home/programs/codex/default.nix`, so `bwrap` is on PATH when codex is enabled on Linux (macOS uses Seatbelt and does not need it). Verified with `nix flake check` (darwin; Linux branch evaluates cleanly).

--- a/home/programs/codex/default.nix
+++ b/home/programs/codex/default.nix
@@ -56,6 +56,10 @@ in
     dotfiles.programs.codex.skillsDirs = [ aiSkills.builtinSkillsDir ];
     dotfiles.programs.zsh.extraSessionPaths = [ "$HOME/.local/bin" ];
 
+    # On Linux, Codex sandboxes commands with bubblewrap (`bwrap`), expecting it
+    # on PATH. macOS uses Seatbelt instead, so it is only needed here.
+    home.packages = lib.optionals pkgs.stdenv.isLinux [ pkgs.bubblewrap ];
+
     assertions = [
       {
         assertion = skills.conflicts == [ ];


### PR DESCRIPTION
## Summary

Codex sandboxes commands with bubblewrap (`bwrap`) on Linux and expects it on PATH (similar to how it shells out to an ambient `rg`). This adds `pkgs.bubblewrap` to `home.packages` when codex is enabled on Linux. macOS uses Seatbelt, so it is gated behind `pkgs.stdenv.isLinux`.

## Testing

- `nix flake check` passes (darwin; the Linux branch evaluates cleanly).

Bean: dotfiles-040q

🤖 Generated with [Claude Code](https://claude.com/claude-code)