### PR TITLE
home/programs/claude-code: add defaultMode permission setting

### DIFF
--- a/.beans/dotfiles-1afe--claude-code-add-defaultmode-permission-setting.md
+++ b/.beans/dotfiles-1afe--claude-code-add-defaultmode-permission-setting.md
@@ -1,0 +1,23 @@
+---
+# dotfiles-1afe
+title: 'claude-code: add defaultMode permission setting'
+status: completed
+type: feature
+priority: normal
+created_at: 2026-06-30T16:15:29Z
+updated_at: 2026-06-30T18:29:42Z
+---
+
+Add a `defaultMode` option to the claude-code module's permissions submodule, written to settings.json as `permissions.defaultMode`. Defaults to "auto".
+
+Docs: https://code.claude.com/docs/en/permission-modes#switch-permission-modes
+
+## Tasks
+
+- [x] Add `defaultMode` field (nullOr enum, default "auto") to the permissions submodule in home/programs/claude-code/default.nix
+- [x] Emit permissions with defaultMode stripped when null (settingsJson builder)
+- [x] nixfmt + nix flake check
+
+## Summary of Changes
+
+Added a `defaultMode` field to the `permissions` submodule in `home/programs/claude-code/default.nix` (type `nullOr (enum [...6 modes])`, default `"auto"`). The `settingsJson` builder now constructs `permissions` from `allow`/`deny` and merges in `defaultMode` only when non-null (via `lib.optionalAttrs`), so it serializes to `permissions.defaultMode` in `~/.claude/settings.json`. Verified by evaluating the module: the default config emits `"defaultMode":"auto"`.

--- a/home/programs/claude-code/default.nix
+++ b/home/programs/claude-code/default.nix
@@ -29,7 +29,12 @@ let
         alwaysThinkingEnabled = true;
         autoMemoryEnabled = false;
         hooks = mergedHooks;
-        permissions = cfg.permissions;
+        permissions = {
+          inherit (cfg.permissions) allow deny;
+        }
+        // lib.optionalAttrs (cfg.permissions.defaultMode != null) {
+          inherit (cfg.permissions) defaultMode;
+        };
       }
       // lib.optionalAttrs (cfg.statusLine != null) {
         statusLine = cfg.statusLine;
@@ -80,6 +85,25 @@ in
             type = types.listOf types.str;
             default = [ ];
             description = "List of permissions to deny.";
+          };
+          defaultMode = mkOption {
+            type = types.nullOr (
+              types.enum [
+                "default"
+                "acceptEdits"
+                "plan"
+                "auto"
+                "dontAsk"
+                "bypassPermissions"
+              ]
+            );
+            default = "auto";
+            description = ''
+              Default permission mode written to settings.json as
+              permissions.defaultMode. Defaults to "auto". Set to null to
+              omit the key entirely. See
+              https://code.claude.com/docs/en/permission-modes#switch-permission-modes.
+            '';
           };
         };
       };


### PR DESCRIPTION
Add a `defaultMode` field to the claude-code module's `permissions` submodule, written to `~/.claude/settings.json` as `permissions.defaultMode` (per the [permission modes docs](https://code.claude.com/docs/en/permission-modes#switch-permission-modes)).

- Type is `nullOr (enum [ "default" "acceptEdits" "plan" "auto" "dontAsk" "bypassPermissions" ])`, defaulting to `"auto"`.
- The `settingsJson` builder constructs `permissions` from `allow`/`deny` and merges in `defaultMode` only when non-null (`lib.optionalAttrs`), matching the existing idiom used for `statusLine`/`skillOverrides`. Setting it to `null` omits the key entirely.

Verified by evaluating the module: the default config emits `"permissions": { ..., "defaultMode": "auto" }`.

Bean: dotfiles-1afe

Follow-ups: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)