### PR TITLE
flake: add nixfmt check to nix flake check

### DIFF
--- a/.beans/dotfiles-aubb--include-nixfmt-on-nix-flake-check.md
+++ b/.beans/dotfiles-aubb--include-nixfmt-on-nix-flake-check.md
@@ -1,11 +1,30 @@
 ---
 # dotfiles-aubb
 title: Include nixfmt on `nix flake check`
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-06-06T20:11:28Z
-updated_at: 2026-06-06T20:11:28Z
+updated_at: 2026-07-04T20:42:09Z
 ---
 
 We've included Rust format/lint/test in `nix flake check`, we should do the same for `nixfmt` runs
+
+## Summary of Changes
+
+Added a `nixfmt` flake check so `nix flake check` (and thus CI) gates Nix
+formatting, mirroring the existing Rust `rust-fmt` check.
+
+- `flake.nix`: new `mkNixfmtCheck` helper builds a `runCommandLocal` derivation
+  that runs `nixfmt --check` over the repo's `.nix` files. Source is a
+  `fileFilter`/`toSource` fileset of the git-filtered flake tree, so vendored
+  `.direnv` third-party Nix is excluded and the check only re-runs when `.nix`
+  files change. Wired into `checks.<system>` as `nixfmt` for both
+  aarch64-darwin and x86_64-linux. Uses `find … -exec nixfmt --check {} +`
+  (nixfmt 1.2.0 deprecates directory args; also avoids a vacuous stdin pass on
+  an empty set).
+- `CLAUDE.md`: note that `nix flake check` also checks Nix formatting; bump
+  freshness date.
+
+Verified: clean tree passes the check (exit 0); a staged misformatted `.nix`
+file fails it (exit 1, "not formatted").

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Nix-based system configuration for macOS and NixOS.
 
-Freshness: 2026-06-06
+Freshness: 2026-07-04
 
 ## Tech Stack
 
@@ -16,7 +16,7 @@ Freshness: 2026-06-06
 
 No justfile at the repo root. Common operations:
 
-- `nix flake check` — validate the flake; also builds and tests the Rust workspace (this is what CI runs)
+- `nix flake check` — validate the flake; also checks Nix formatting (the `nixfmt` check) and builds/tests the Rust workspace (this is what CI runs)
 - `nix flake show` — list outputs (systems, templates, lib)
 - `nixfmt <file>` — format Nix files (available in the devShell)
 - `cargo test --workspace` — run Rust tests directly without going through Nix (see `crates/CLAUDE.md`)

--- a/flake.nix
+++ b/flake.nix
@@ -218,6 +218,22 @@
 
       mkPackages = pkgs: builtins.removeAttrs pkgs.dotfiles [ "internal" ];
 
+      # `nixfmt --check` gate as a flake check, mirroring crates/'s `rust-fmt`.
+      # `fileFilter` over the git-filtered flake source keeps vendored `.direnv`
+      # Nix out; `-exec` passes files explicitly (nixfmt 1.2.0 deprecates dir args).
+      mkNixfmtCheck =
+        pkgs:
+        let
+          src = pkgs.lib.fileset.toSource {
+            root = ./.;
+            fileset = pkgs.lib.fileset.fileFilter (file: file.hasExt "nix") ./.;
+          };
+        in
+        pkgs.runCommandLocal "nixfmt-check" { nativeBuildInputs = [ pkgs.nixfmt ]; } ''
+          find ${src} -name '*.nix' -exec nixfmt --check {} +
+          touch $out
+        '';
+
     in
     {
       lib = {
@@ -243,11 +259,25 @@
           system = "x86_64-linux";
         });
       };
-      checks = {
-        aarch64-darwin = self.packages.aarch64-darwin // (nixDarwinPkgs { }).dotfiles.internal.rustChecks;
-        x86_64-linux =
-          self.packages.x86_64-linux // (nixOsPkgs { system = "x86_64-linux"; }).dotfiles.internal.rustChecks;
-      };
+      checks =
+        let
+          darwinPkgs = nixDarwinPkgs { };
+          linuxPkgs = nixOsPkgs { system = "x86_64-linux"; };
+        in
+        {
+          aarch64-darwin =
+            self.packages.aarch64-darwin
+            // darwinPkgs.dotfiles.internal.rustChecks
+            // {
+              nixfmt = mkNixfmtCheck darwinPkgs;
+            };
+          x86_64-linux =
+            self.packages.x86_64-linux
+            // linuxPkgs.dotfiles.internal.rustChecks
+            // {
+              nixfmt = mkNixfmtCheck linuxPkgs;
+            };
+        };
       templates = {
         "system/darwin" = {
           path = ./templates/systems/darwin;


### PR DESCRIPTION
Adds a `nixfmt` flake check so `nix flake check` (and therefore CI) gates Nix formatting, mirroring the existing Rust `rust-fmt` check.

## What changed
- `flake.nix`: new `mkNixfmtCheck` helper — a `runCommandLocal` derivation that runs `nixfmt --check` over the repo's `.nix` files. The source is a `fileFilter`/`toSource` fileset of the git-filtered flake tree, so vendored `.direnv` third-party Nix is excluded and the check only re-runs when `.nix` files change. Wired into `checks.<system>` as `nixfmt` for both `aarch64-darwin` and `x86_64-linux`. Uses `find … -exec nixfmt --check {} +` (nixfmt 1.2.0 deprecates directory args, and this avoids a vacuous stdin pass on an empty file set).
- `CLAUDE.md`: note that `nix flake check` also checks Nix formatting; bump freshness date.

## Verification
- Clean tree: `nix build .#checks.aarch64-darwin.nixfmt` passes (exit 0).
- Negative: staging a deliberately-misformatted tracked `.nix` file fails the check (exit 1, `not formatted`).

Follow-ups: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)