### PR TITLE
crates beansd: use customizable <select> for project switcher

### DIFF
--- a/.beans/dotfiles-6epm--beansd-use-custom-select-element-for-project-selec.md
+++ b/.beans/dotfiles-6epm--beansd-use-custom-select-element-for-project-selec.md
@@ -1,0 +1,30 @@
+---
+# dotfiles-6epm
+title: '[beansd] Use custom select element for project selector'
+status: completed
+type: task
+priority: normal
+created_at: 2026-06-10T07:17:19Z
+updated_at: 2026-07-04T21:15:25Z
+---
+
+This will provide a more native experience - https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select
+
+## Summary of Changes
+
+Replaced the `<details>`/`<summary>` disclosure-hack project switcher with the
+customizable native `<select>` element (`appearance: base-select`) in
+`top_bar.html`, restyled in `app.css`:
+
+- The `<button>` + `<selectedcontent>` mirrors the active project's name (path
+  and badge hidden in the button, shown in the picker rows).
+- A disabled/hidden placeholder `<option>` is always rendered as the button-label
+  fallback; the active project's option carries `selected` and wins by document
+  order, so unknown/absent keys fall back cleanly to "Select a project".
+- Selection navigates via an `onchange` handler that URL-encodes the project key
+  (more robust than the old raw-path anchors).
+- Suppressed the UA's default `::picker-icon` in favour of the existing caret,
+  and kept the placeholder out of the picker via `option[hidden]`.
+
+Added a render assertion in `partial_lists_registered_projects` pinning the
+placeholder + selected-option contract.

--- a/crates/beansd/src/web/routes/html/projects.rs
+++ b/crates/beansd/src/web/routes/html/projects.rs
@@ -149,7 +149,7 @@ mod tests {
         let app = router().with_state(build_state(Arc::new(Mutex::new(r))));
         let resp = app
             .oneshot(
-                Request::get("/partials/topbar")
+                Request::get("/partials/topbar?active=/tmp/p")
                     .body(axum::body::Body::empty())
                     .unwrap(),
             )
@@ -166,6 +166,17 @@ mod tests {
         assert!(
             body.contains("/tmp/p"),
             "path should appear in the dropdown row"
+        );
+        // The placeholder is always rendered as a disabled/hidden fallback for
+        // the button label; the active project's option carries `selected` and,
+        // being later in document order, wins over the placeholder.
+        assert!(
+            body.contains(r#"<option value="" disabled selected hidden>"#),
+            "placeholder option should be a disabled/hidden fallback"
+        );
+        assert!(
+            body.contains(r#"<option value="/tmp/p" selected>"#),
+            "active project option should be marked selected"
         );
     }
 

--- a/crates/beansd/src/web/static/app.css
+++ b/crates/beansd/src/web/static/app.css
@@ -16,52 +16,78 @@ body {
   gap: 1rem;
 }
 
-details.project-switcher { position: relative; }
-details.project-switcher > summary {
-  list-style: none;
-  padding: 0.35rem 0.6rem;
-  border-radius: 4px;
-  cursor: pointer;
+/* Customizable <select> (appearance: base-select). Where the API is
+   unsupported the browser falls back to a native select; the extra
+   <button>/<selectedcontent> markup may render imperfectly, but the options
+   remain selectable. Targeting evergreen Chromium; not tested on older engines. */
+select.project-switcher {
+  appearance: base-select;
+  font: inherit;
+  color: inherit;
+  border: none;
+  background: transparent;
+  padding: 0;
 }
-details.project-switcher > summary::-webkit-details-marker { display: none; }
-details.project-switcher > summary:hover { background: #313244; }
 
-.caret { opacity: 0.6; margin-left: 0.3rem; }
-
-details[open] > .panel {
-  position: absolute;
-  top: 100%;
-  left: 0;
+select.project-switcher::picker(select) {
+  appearance: base-select;
   min-width: 280px;
   max-width: 480px;
   background: #1e1e2e;
   border: 1px solid #313244;
   border-radius: 4px;
-  z-index: 10;
   max-height: 60vh;
   overflow-y: auto;
   margin-top: 0.25rem;
+  padding: 0;
 }
 
-.project-row {
+select.project-switcher > button {
+  appearance: none;
+  font: inherit;
+  color: inherit;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  padding: 0.35rem 0.6rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+select.project-switcher > button:hover { background: #313244; }
+
+/* Suppress the UA's default picker arrow — we render our own .caret. */
+select.project-switcher::picker-icon { display: none; }
+
+/* The button mirrors the selected option; show only its name, not path/badge. */
+select.project-switcher selectedcontent .path,
+select.project-switcher selectedcontent .badge { display: none; }
+
+.caret { opacity: 0.6; margin-left: 0.3rem; }
+
+select.project-switcher option {
   display: grid;
   grid-template-columns: 1fr auto;
   column-gap: 0.75rem;
   padding: 0.5rem 0.75rem;
-  color: inherit;
-  text-decoration: none;
+  color: #cdd6f4;
+  cursor: pointer;
 }
-.project-row .name { grid-column: 1; grid-row: 1; font-weight: 500; }
-.project-row .path {
+select.project-switcher option::checkmark { display: none; }
+/* The placeholder option is a fallback for the button label only; keep it out
+   of the picker (the base-select picker ignores the `hidden` attribute). */
+select.project-switcher option[hidden] { display: none; }
+select.project-switcher option .name { grid-column: 1; grid-row: 1; font-weight: 500; }
+select.project-switcher option .path {
   grid-column: 1;
   grid-row: 2;
   font-family: ui-monospace, monospace;
   font-size: 0.7rem;
   opacity: 0.6;
 }
-.project-row .badge { grid-column: 2; grid-row: 1 / 3; align-self: center; }
-.project-row:hover { background: #313244; }
-.project-row.active { background: #45475a; }
+select.project-switcher option .badge { grid-column: 2; grid-row: 1 / 3; align-self: center; }
+select.project-switcher option:hover { background: #313244; }
+select.project-switcher option:checked { background: #45475a; }
 
 .topbar-detail {
   display: flex;

--- a/crates/beansd/src/web/templates/top_bar.html
+++ b/crates/beansd/src/web/templates/top_bar.html
@@ -1,19 +1,18 @@
-<details class="project-switcher">
-  <summary>
-    {% if let Some(p) = active_project %}{{ p.display_name }}{% else %}Select a project{% endif %}
+<select class="project-switcher" aria-label="Select a project"
+        onchange="if (this.value) location.assign('/?project=' + encodeURIComponent(this.value));">
+  <button>
+    <selectedcontent></selectedcontent>
     <span class="caret">▾</span>
-  </summary>
-  <div class="panel">
-    {% for p in projects %}
-    <a class="project-row{% if Some(p.key.clone()) == active_key %} active{% endif %}"
-       href="/?project={{ p.key.display() }}">
-      <div class="name">{{ p.display_name }}</div>
-      <div class="path">{{ p.key.display() }}</div>
-      <span class="badge {{ p.state }}">{{ p.state }}</span>
-    </a>
-    {% endfor %}
-  </div>
-</details>
+  </button>
+  <option value="" disabled selected hidden>Select a project</option>
+  {% for p in projects %}
+  <option value="{{ p.key.display() }}"{% if Some(p.key.clone()) == active_key %} selected{% endif %}>
+    <span class="name">{{ p.display_name }}</span>
+    <span class="path">{{ p.key.display() }}</span>
+    <span class="badge {{ p.state }}">{{ p.state }}</span>
+  </option>
+  {% endfor %}
+</select>
 {% if let Some(p) = active_project %}
 <div class="topbar-detail">
   <span class="badge {{ p.state }}">{{ p.state }}</span>


### PR DESCRIPTION
Replaces the `<details>`/`<summary>` disclosure-hack project switcher in the beansd launcher top bar with the native customizable `<select>` element (`appearance: base-select`), for a more native picker experience.

## What changed
- **`top_bar.html`** — `<select>` with a `<button>`/`<selectedcontent>` label and one `<option>` per project. Selection navigates via an `onchange` handler that URL-encodes the project key (more robust than the old raw-path anchors).
- **Placeholder fallback** — a `disabled selected hidden` placeholder option is always rendered; the active project's option carries `selected` and wins by document order, so unknown/absent keys fall back cleanly to "Select a project".
- **`app.css`** — restyled the switcher, its `::picker(select)` popup, and options; suppressed the UA `::picker-icon` in favour of the existing caret; kept the placeholder out of the picker via `option[hidden]`.
- **Test** — added a render assertion in `partial_lists_registered_projects` pinning the placeholder + selected-option contract.

Verified live against a dev daemon (`--dev`, port 9001) with active/inactive projects. `cargo test --workspace`, `cargo fmt --check`, and `cargo clippy -D warnings` all pass.

Note: targets evergreen Chromium; where `appearance: base-select` is unsupported the browser falls back to a native select (options still selectable).

Follow-ups: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)