### PR TITLE
crates: silence crane placeholder-name evaluation warnings

### DIFF
--- a/.beans/dotfiles-ehl3--silence-crane-placeholder-name-evaluation-warnings.md
+++ b/.beans/dotfiles-ehl3--silence-crane-placeholder-name-evaluation-warnings.md
@@ -1,11 +1,11 @@
 ---
 # dotfiles-ehl3
 title: Silence crane placeholder-name evaluation warnings
-status: todo
+status: completed
 type: task
 priority: low
 created_at: 2026-06-11T10:28:18Z
-updated_at: 2026-06-11T10:28:18Z
+updated_at: 2026-07-10T16:36:04Z
 ---
 
 Since the Rust build moved onto crane, `nix` evaluation emits a warning:
@@ -27,6 +27,16 @@ The repo root `Cargo.toml` is a *virtual* workspace manifest (`[workspace]` only
 
 Set an explicit name on the shared args so crane stops guessing. Options (per the crane warning text):
 
-- [ ] Add `pname` (+ maybe `version`) to `commonArgs` in `crates/default.nix` — simplest; gives the deps cache / checks a stable name
+- [x] Add `pname` (+ maybe `version`) to `commonArgs` in `crates/default.nix` — simplest; gives the deps cache / checks a stable name
 - [ ] Or set `workspace.metadata.crane.name = "..."` in the root `Cargo.toml`
-- [ ] Verify `nix flake check` is warning-free afterwards (e.g. `NIX_ABORT_ON_WARN=1 nix --option pure-eval false --show-trace ...` to confirm no remaining sources)
+- [x] Verify `nix flake check` is warning-free afterwards (e.g. `NIX_ABORT_ON_WARN=1 nix --option pure-eval false --show-trace ...` to confirm no remaining sources)
+
+## Summary of Changes
+
+Silenced crane's `name cannot be found` evaluation warning that fired during `nix flake check`.
+
+- Added explicit `pname = "dotfiles-rs-workspace"` and `version = "0.1.0"` to the shared `commonArgs` in `crates/default.nix`, so crane no longer substitutes a placeholder for the deps-cache (`buildDepsOnly`) and the `rust-clippy`/`rust-test` checks.
+- Also passed `pname`/`version` to the `rust-fmt` (`cargoFmt`) call, which only inherited `src` from `commonArgs` and so still warned.
+- `buildLocalRustBin` still overrides pname/version with the shipped package's own values, so `beans-daemon` is unchanged; the new name only labels the deps/check derivations.
+
+Verified all four derivations (rust-clippy, rust-test, rust-fmt, beans-daemon) are warning-free and `nix flake check` passes.

--- a/crates/default.nix
+++ b/crates/default.nix
@@ -33,6 +33,13 @@ let
   # clippy/test checks — so cargo deps compile once and every derivation reuses the
   # same `cargoArtifacts`.
   commonArgs = {
+    # The root Cargo.toml is a virtual workspace manifest (`[workspace]`, no
+    # `[package].name`), so crane can't infer a crate name for the deps cache /
+    # checks and warns while substituting a placeholder. Naming the shared args
+    # explicitly silences that. `buildLocalRustBin` overrides pname/version with
+    # the shipped package's own values, so this only labels the deps/check derivations.
+    pname = "dotfiles-rs-workspace";
+    version = "0.1.0";
     # Full workspace tree, not `cleanCargoSource`: `beansd` embeds non-Rust assets
     # (askama `.html` templates compiled by the derive macro, plus `.css`/`.js`
     # static files) that the cargo-only filter would strip. `buildDepsOnly` keys
@@ -56,7 +63,7 @@ let
   # (not `beans-daemon-*`) because `--workspace` means they cover every crate, not
   # just the shipped package.
   rustChecks = {
-    rust-fmt = craneLib.cargoFmt { inherit (commonArgs) src; };
+    rust-fmt = craneLib.cargoFmt { inherit (commonArgs) src pname version; };
     rust-clippy = craneLib.cargoClippy (
       commonArgs
       // {


### PR DESCRIPTION
The root `Cargo.toml` is a virtual workspace manifest (`[workspace]` only, no `[package].name`), so crane can't infer a crate name for the shared `commonArgs` and substitutes a placeholder — warning on every `nix flake check` evaluation for the deps cache (`buildDepsOnly`) and the `rust-*` checks.

Fix: give `commonArgs` an explicit `pname = "dotfiles-rs-workspace"` / `version = "0.1.0"`, and pass them to the `cargoFmt` (`rust-fmt`) call too, which only inherited `src` and so still warned. `buildLocalRustBin` continues to override pname/version with the shipped package's own values, so the `beans-daemon` package is unchanged — the new name only labels the deps/check derivations.

Verified all four derivations (`rust-clippy`, `rust-test`, `rust-fmt`, `beans-daemon`) are warning-free and `nix flake check` passes.

Follow-ups: none

Bean: dotfiles-ehl3

🤖 Generated with [Claude Code](https://claude.com/claude-code)