### PR TITLE
home/programs/codex: default approvals_reviewer to auto_review

### DIFF
--- a/.beans/dotfiles-60h5--default-approvals-reviewer-to-auto-review-in-codex.md
+++ b/.beans/dotfiles-60h5--default-approvals-reviewer-to-auto-review-in-codex.md
@@ -1,0 +1,20 @@
+---
+# dotfiles-60h5
+title: Default approvals_reviewer to auto_review in codex module
+status: completed
+type: task
+priority: normal
+created_at: 2026-07-13T09:37:33Z
+updated_at: 2026-07-13T09:38:29Z
+---
+
+Expose a configurable dotfiles.programs.codex.approvalsReviewer option (default "auto_review") that renders into a managed -c override in home/programs/codex/default.nix.
+
+- [x] Add approvalsReviewer mkOption
+- [x] Add approvals_reviewer entry to managedConfig
+- [x] Update managedConfig comment to document string quoting
+- [x] nixfmt + nix flake check
+
+## Summary of Changes
+
+Added a configurable `dotfiles.programs.codex.approvalsReviewer` option (type str, default `"auto_review"`) in `home/programs/codex/default.nix`, feeding a new `approvals_reviewer` entry in the `managedConfig` attrset. The value embeds its own TOML quotes so the wrapper injects `-c 'approvals_reviewer="auto_review"'`. Updated the `managedConfig` comment to document string-value quoting. Verified via `nix flake check` (all checks pass, incl. nixfmt) and by evaluating the rendered `-c` args.

--- a/home/programs/codex/default.nix
+++ b/home/programs/codex/default.nix
@@ -21,9 +21,11 @@ let
   # Managed Codex settings, injected as session-only `-c key=value` overrides
   # (precedence 30). Codex never persists `-c` flags, so there is no managed file
   # for it to clobber. Dotted keys map straight to Codex config paths; bool values
-  # render as bare TOML `true`/`false`.
+  # render as bare TOML `true`/`false`; string values embed their own TOML quotes
+  # (e.g. `''"auto_review"''`).
   managedConfig = {
     "features.hooks" = lib.boolToString cfg.enableHooks;
+    "approvals_reviewer" = ''"${cfg.approvalsReviewer}"'';
   };
   configArgs = lib.concatStringsSep " " (
     lib.mapAttrsToList (k: v: "-c ${lib.escapeShellArg "${k}=${v}"}") managedConfig
@@ -44,6 +46,11 @@ in
       type = types.bool;
       default = true;
       description = "Enable Codex lifecycle hooks ([features].hooks), injected as a -c session flag by the codex wrapper.";
+    };
+    approvalsReviewer = mkOption {
+      type = types.str;
+      default = "auto_review";
+      description = "Value for Codex's approvals_reviewer setting, injected as a -c session flag by the codex wrapper.";
     };
     hooks = mkOption {
       type = types.attrsOf hookTypes.hookType;


### PR DESCRIPTION
## What & why

Manage Codex's `approvals_reviewer` setting declaratively so it defaults to `auto_review` — Codex runs its reviewer automatically without hand-editing `~/.codex/config.toml`.

Adds a configurable `dotfiles.programs.codex.approvalsReviewer` option (`types.str`, default `"auto_review"`), mirroring the existing `enableHooks` knob. It feeds a new `approvals_reviewer` entry in the `managedConfig` attrset, which the codex wrapper injects as a session-only override: `-c 'approvals_reviewer="auto_review"'` (precedence 30, per `docs/specs/2026-06-04-codex-config-c-injection.md`). String values embed their own TOML quotes; the `managedConfig` comment was updated to document this.

## Verification

- `nix flake check` passes (incl. the `nixfmt` gate).
- Rendered `-c` args confirmed via `nix eval`: `-c 'approvals_reviewer="auto_review"' -c 'features.hooks=true'`.
- Subagent review: no Blocking/Required findings.

Follow-ups: none (optional hardening to `types.enum` considered and deferred as unnecessary for a fixed in-module value)

Bean: dotfiles-60h5

🤖 Generated with [Claude Code](https://claude.com/claude-code)