### PR TITLE
templates/projects: update to Nixpkgs 26.05

### DIFF
--- a/.beans/dotfiles-c42i--update-project-templates-to-nixpkgs-2605.md
+++ b/.beans/dotfiles-c42i--update-project-templates-to-nixpkgs-2605.md
@@ -1,10 +1,20 @@
 ---
 # dotfiles-c42i
 title: Update project templates to Nixpkgs 26.05
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-06-06T17:39:36Z
-updated_at: 2026-06-06T17:39:36Z
+updated_at: 2026-08-02T09:52:08Z
 ---
 
+## Summary of Changes
+
+Bumped the `nixpkgs` input pin in both project templates from `nixos-25.11` to `nixos-26.05`, matching the root flake:
+
+- `templates/projects/go/flake.nix`
+- `templates/projects/typescript/flake.nix`
+
+The system templates (`templates/systems/*`) don't pin nixpkgs — they consume it via the `dotfiles` flake input — so they needed no change.
+
+Verified by building `devShells.x86_64-linux.default` for both templates against 26.05; every package resolves (go, gopls, gotools, golangci-lint, nil, nixfmt, nodejs). `nixfmt --check` passes.

--- a/templates/projects/go/flake.nix
+++ b/templates/projects/go/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     systems.url = "github:nix-systems/default";
   };
 

--- a/templates/projects/typescript/flake.nix
+++ b/templates/projects/typescript/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     systems.url = "github:nix-systems/default";
   };
 


### PR DESCRIPTION
Bump the `nixpkgs` input pin in the go and typescript project templates from `nixos-25.11` to `nixos-26.05`, matching the root flake.

The system templates (`templates/systems/*`) don't pin nixpkgs — they consume it through the `dotfiles` flake input — so they needed no change.

Verified by building `devShells.x86_64-linux.default` for both templates against 26.05; every package resolves (go, gopls, gotools, golangci-lint, nil, nixfmt, nodejs).

Bean: dotfiles-c42i

Follow-ups: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)