### PR TITLE
Plan: package agent skills as Claude Code plugins

### DIFF
--- a/.beans/dotfiles-0ivn--convert-plannotator-to-the-df-plannotator-plugin.md
+++ b/.beans/dotfiles-0ivn--convert-plannotator-to-the-df-plannotator-plugin.md
@@ -1,0 +1,128 @@
+---
+# dotfiles-0ivn
+title: Convert plannotator to the df-plannotator plugin
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-02T12:17:06Z
+updated_at: 2026-08-02T12:17:06Z
+parent: dotfiles-u1q7
+blocked_by:
+    - dotfiles-e4zf
+---
+
+Converts plannotator from two hand-wired entries (a `skillsDirs` append plus a `hooks` append on the claude-code module) into a single `dotfiles.ai.plugins.plannotator` declaration.
+
+Its Codex hook stays where it is: the two assistants fire plannotator on different events (`PermissionRequest`/`ExitPlanMode` for Claude Code, `Stop` for Codex), so it is not shared plugin content under this design.
+
+**Files:**
+- Modify: `home/programs/plannotator/default.nix`
+
+- [ ] **Step 1: Declare the plugin in the shared branch**
+
+`config` is a `lib.mkMerge` of three branches. The plugin's skill is wanted whenever either assistant is on, so declare it in the first (shared) branch alongside the package and config file:
+
+```nix
+    (lib.mkIf (cfg.claude-code.enable || cfg.codex.enable) {
+      home.packages = [ plannotatorWrapper ];
+      home.file.".plannotator/config.json".source = configJson;
+
+      dotfiles.ai.plugins.plannotator = {
+        enable = true;
+        description = "Plan and code review gates via plannotator";
+        defaultEnabled = true;
+        skillDirs = [ ./skills ];
+      };
+    })
+```
+
+- [ ] **Step 2: Move each assistant's hook onto its own surface**
+
+Replace the `claude-code` branch:
+
+```nix
+    (lib.mkIf cfg.claude-code.enable {
+      dotfiles.programs.claude-code.skillsDirs = [ ./skills ];
+      dotfiles.programs.claude-code.hooks.plannotator-review =
+        plannotatorHook "PermissionRequest" "ExitPlanMode";
+    })
+```
+
+with a branch that contributes only the hook, into the plugin declared in Step 1:
+
+```nix
+    (lib.mkIf cfg.claude-code.enable {
+      dotfiles.ai.plugins.plannotator.hooks.plannotator-review =
+        plannotatorHook "PermissionRequest" "ExitPlanMode";
+    })
+```
+
+`plannotatorHook` already returns exactly the shape `hooks` expects (`{ enable, event, matcher, hooks }`), so it is reused unchanged, and `mkMerge` combines this branch's `hooks` with Step 1's `skillDirs`.
+
+In the `codex` branch, delete only this line — the skill now reaches Codex through the flattened plugin `skillDirs` wired up in the previous task:
+
+```nix
+      dotfiles.programs.codex.skillsDirs = [ ./skills ];
+```
+
+Its hook stays module-level and unchanged:
+
+```nix
+      dotfiles.programs.codex.hooks.plannotator-review = plannotatorHook "Stop" null;
+```
+
+Update the comment above `plannotatorHook` to say that the Claude Code hook now ships inside the plugin while the Codex one stays on the module, because the events differ.
+
+- [ ] **Step 3: Verify eval**
+
+Run: `nix build .#checks.x86_64-linux.home-eval --no-link --print-out-paths`
+
+Expected: passes. `cat` the path and confirm `.claude/skills/df-plannotator` is present and `.claude/skills/plannotator-user-code-review` is gone, while `.codex/skills/plannotator-user-code-review` remains.
+
+- [ ] **Step 4: Validate the rendered plugin**
+
+```bash
+nix build --impure --no-link --print-out-paths --expr '
+  let
+    flake = builtins.getFlake (toString ./.);
+    hm = flake.lib.mkHomeManagerSystem {
+      system = "x86_64-linux";
+      user = "check";
+      directory = "/home/check";
+      home = ./checks/home-eval.nix;
+    };
+  in
+  hm.config.home.file.".claude/skills/df-plannotator".source'
+```
+
+With that path as `$P`:
+
+```bash
+HOME=$(mktemp -d) claude plugin validate $P
+cat $P/hooks/hooks.json
+```
+
+Expected: validation passes; `hooks.json` has a `PermissionRequest` entry with `"matcher":"ExitPlanMode"`, a command ending in `/bin/plannotator`, and `"timeout":345600`.
+
+- [ ] **Step 5: Confirm the skill is namespaced as expected**
+
+```bash
+T=$(mktemp -d); mkdir -p $T/.claude/skills
+cp -r $P $T/.claude/skills/df-plannotator
+HOME=$T claude plugin details df-plannotator@skills-dir
+```
+
+Expected: `Skills (1)  plannotator-user-code-review` and `Hooks (1)`. In a real session it is invoked as `df-plannotator:plannotator-user-code-review`.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+nixfmt home/programs/plannotator/default.nix
+git add home/programs/plannotator/default.nix
+git commit -m "home/programs/plannotator: ship as the df-plannotator plugin
+
+Replaces the separate skillsDirs and hooks wiring with one plugin
+declaration. The codex hook stays module-level; its event differs.
+
+Bean: dotfiles-0ivn"
+```

--- a/.beans/dotfiles-36nb--remove-the-per-assistant-skillsdirs-options.md
+++ b/.beans/dotfiles-36nb--remove-the-per-assistant-skillsdirs-options.md
@@ -1,0 +1,100 @@
+---
+# dotfiles-36nb
+title: Remove the per-assistant skillsDirs options
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-02T12:17:06Z
+updated_at: 2026-08-02T12:17:06Z
+parent: dotfiles-u1q7
+blocked_by:
+    - dotfiles-0ivn
+    - dotfiles-vjte
+---
+
+With every consumer moved to `dotfiles.ai.plugins`, the per-assistant `skillsDirs` options have no remaining setters. Remove them so there is exactly one way to contribute skills — leaving both mechanisms alive would invite new code to pick the wrong one.
+
+**Files:**
+- Modify: `home/programs/claude-code/default.nix`, `home/programs/codex/default.nix`, `home/programs/cursor/default.nix`
+
+- [ ] **Step 1: Confirm nothing sets the options any more**
+
+Run: `grep -rn "skillsDirs" home/`
+
+Expected: matches only inside the three module files (their own `mkOption` declaration and their `mkSkillFiles`/`mkPluginFiles` call sites). If any other file still assigns `skillsDirs`, convert it to a plugin before continuing.
+
+- [ ] **Step 2: Remove the option from the claude-code module**
+
+In `home/programs/claude-code/default.nix`, delete the `skillsDirs = mkOption { ... };` block, and delete the now-unused `skills` binding and its `aiSkills` import together with the assertion and `home.file` entry that reference them:
+
+- delete the `aiSkills = import ../../lib/ai/skills { inherit lib pkgs; };` binding
+- delete the `skills = aiSkills.mkSkillFiles { ... };` binding
+- delete the assertion whose message begins `claude-code: skill name conflicts`
+- in `home.file`, drop the `// skills.files` term, leaving `// plugins.files`
+
+Claude Code now receives skills exclusively as plugin content.
+
+- [ ] **Step 3: Remove the option from the codex module**
+
+In `home/programs/codex/default.nix`, delete the `skillsDirs = mkOption { ... };` block and simplify the `skills` binding to use the plugin-derived list only:
+
+```nix
+  skills = aiSkills.mkSkillFiles {
+    variant = "codex";
+    targetDir = ".codex/skills";
+    skillsDirs = pluginSkillDirs;
+    # Codex follows symlinked skill directories but ignores symlinked SKILL.md
+    # files, so symlink the directory itself rather than recreating the tree.
+    recursive = false;
+  };
+```
+
+Keep the existing assertion on `skills.conflicts`: Codex flattens every plugin's skills into one directory, so cross-plugin name collisions are still real failures there.
+
+- [ ] **Step 4: Remove the option from the cursor module**
+
+Apply the same edit to `home/programs/cursor/default.nix`:
+
+```nix
+  skills = aiSkills.mkSkillFiles {
+    variant = "cursor";
+    targetDir = ".cursor/skills";
+    skillsDirs = pluginSkillDirs;
+  };
+```
+
+Keep its `skills.conflicts` assertion for the same reason.
+
+- [ ] **Step 5: Verify eval and compare the file set**
+
+Run: `nix build .#checks.x86_64-linux.home-eval --no-link --print-out-paths`
+
+Expected: passes. `cat` the path and confirm the set is unchanged from the previous task — `.claude/skills/df-base`, `.claude/skills/df-plannotator`, `.claude/skills/df-beans`, plus the flattened `.codex/skills/*` and `.cursor/skills/*` entries including `plannotator-user-code-review`.
+
+- [ ] **Step 6: Verify the cross-plugin collision assertion still bites**
+
+Temporarily add a second `skillDirs` entry to `checks/home-eval.nix` that duplicates an existing skill name:
+
+```nix
+  dotfiles.ai.plugins.probe = {
+    enable = true;
+    description = "probe";
+    skillDirs = [ ../home/lib/ai/skills ];
+  };
+```
+
+Run: `nix build .#checks.x86_64-linux.home-eval --no-link`
+
+Expected: FAIL, with the codex or cursor message `skill name conflicts between built-in skills and provided skills: brainstorming, ...`. This confirms the flattened assertion survived the refactor. Remove the probe block and re-run to confirm it passes again.
+
+- [ ] **Step 7: Format and commit**
+
+```bash
+nixfmt home/programs/claude-code/default.nix home/programs/codex/default.nix home/programs/cursor/default.nix
+git add home/programs/claude-code/default.nix home/programs/codex/default.nix home/programs/cursor/default.nix
+git commit -m "home/programs: drop the per-assistant skillsDirs options
+
+dotfiles.ai.plugins is now the only way to contribute skills.
+
+Bean: dotfiles-36nb"
+```

--- a/.beans/dotfiles-6f5q--home-manager-eval-check-harness.md
+++ b/.beans/dotfiles-6f5q--home-manager-eval-check-harness.md
@@ -1,0 +1,13 @@
+---
+# dotfiles-6f5q
+title: Home-manager eval check harness
+status: todo
+type: feature
+created_at: 2026-08-02T12:10:36Z
+updated_at: 2026-08-02T12:10:36Z
+parent: dotfiles-zo7y
+---
+
+Adds the first evaluation coverage for `home/`. Today `nix flake check` builds packages, Rust and nixfmt but never evaluates a home-manager configuration, so a broken module or a failing assertion in `home/` reaches CI undetected — and every task in this epic would otherwise be unverifiable.
+
+**Owns:** `checks/home-eval.nix` (a minimal home-manager module enabling the AI-assistant programs) and the `home-eval` check wired into `flake.nix`'s `checks` attribute.

--- a/.beans/dotfiles-6l44--enable-df-beans-for-this-repository.md
+++ b/.beans/dotfiles-6l44--enable-df-beans-for-this-repository.md
@@ -1,0 +1,75 @@
+---
+# dotfiles-6l44
+title: Enable df-beans for this repository
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-02T12:17:06Z
+updated_at: 2026-08-02T12:17:06Z
+parent: dotfiles-u1q7
+blocked_by:
+    - dotfiles-vjte
+---
+
+`df-beans` ships `defaultEnabled = false`, so beans priming is now off everywhere — including in this repository, which does use beans. Opt in by committing the enablement to this repo's `.claude/settings.json`.
+
+This is the "solo project, commit it" case from the design: the entry is versioned so it applies on every machine and every clone, rather than being re-done per checkout in `settings.local.json`.
+
+**Files:**
+- Modify: `.claude/settings.json`
+
+- [ ] **Step 1: Add the enablement entry**
+
+`.claude/settings.json` currently holds only a `permissions.allow` list. Add `enabledPlugins` alongside it:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(nixfmt:*)",
+      "Bash(nix flake check:*)",
+      "Bash(gh pr merge:*)"
+    ]
+  },
+  "enabledPlugins": {
+    "df-beans@skills-dir": true
+  }
+}
+```
+
+- [ ] **Step 2: Verify it is valid JSON**
+
+Run: `jq . .claude/settings.json`
+
+Expected: pretty-printed output, exit 0.
+
+- [ ] **Step 3: Verify the switch takes effect**
+
+This needs the plugin actually installed, so run `home-manager switch` (or the host's switch command) first, then from this repository:
+
+```bash
+claude plugin list
+```
+
+Expected: `df-beans@skills-dir` with `Status: ✔ loaded`, and `df-base@skills-dir` / `df-plannotator@skills-dir` also loaded via their own `defaultEnabled`.
+
+Then check the negative case from any directory outside this repository:
+
+```bash
+cd /tmp && claude plugin list
+```
+
+Expected: `df-beans@skills-dir` reports `Status: ✘ disabled` there. That difference is the whole point of the epic.
+
+- [ ] **Step 4: Confirm the beans hooks fire here and only here**
+
+Start a session in this repository and confirm the beans priming instructions appear in context (the `SessionStart` hook output). Start one in an unrelated directory and confirm they do not.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .claude/settings.json
+git commit -m "beans: enable the df-beans plugin for this repository
+
+Bean: dotfiles-6l44"
+```

--- a/.beans/dotfiles-6qk2--update-claudemd-files-for-the-plugin-structure.md
+++ b/.beans/dotfiles-6qk2--update-claudemd-files-for-the-plugin-structure.md
@@ -1,0 +1,53 @@
+---
+# dotfiles-6qk2
+title: Update CLAUDE.md files for the plugin structure
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-02T12:18:09Z
+updated_at: 2026-08-02T12:18:09Z
+parent: dotfiles-gq4t
+blocked_by:
+    - dotfiles-36nb
+---
+
+The two CLAUDE.md files describe a structure this epic replaces: `home/lib/ai/CLAUDE.md` documents `mkSkillFiles` and the `skillsDirs` contract as the way skills reach assistants, and the root `CLAUDE.md` project-structure block has no `checks/` or `home/lib/ai/plugins/` entry. Both are load-bearing context for future sessions.
+
+**Files:**
+- Modify: `home/lib/ai/CLAUDE.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Rewrite `home/lib/ai/CLAUDE.md`**
+
+Update these sections; keep the existing Purpose / Structure / Contracts / Key Decisions / Invariants / Gotchas shape:
+
+- **Freshness**: set to the date this lands.
+- **Structure**: add `plugins/` with `module.nix` (options), `base.nix` (the `df-base` declaration), `default.nix` (`mkPluginFiles`), `hook-types.nix` (moved from the claude-code module).
+- **Contracts**: state that `dotfiles.ai.plugins.<name>` is the single declaration point; that `mkPluginFiles { variant, targetDir, plugins }` returns `{ files, conflicts }` and installs to `<targetDir>/df-<name>`; that `mkSkillFiles` now serves only Codex and Cursor, which flatten every enabled plugin's `skillDirs`.
+- **Key Decisions**: record that plugins are skills-directory plugins (`df-<name>@skills-dir`) rather than a marketplace — discovery is in place, so there is no registration, no trust prompt and no cache to invalidate; and that the `df-` prefix is fixed because per-project `enabledPlugins` entries reference it forever.
+- **Gotchas**: plugin skills are namespaced (`df-base:brainstorming`) under Claude Code but flat under Codex/Cursor; `defaultEnabled` needs Claude Code ≥ 2.1.154; plugins cannot carry permission allowlists, so those stay on the program modules.
+
+- [ ] **Step 2: Update the root `CLAUDE.md`**
+
+- **Freshness**: set to the date this lands.
+- **Project Structure** block: add `checks/` (the `home-eval` module) and `home/lib/ai/plugins/`.
+- **Commands**: note that `nix flake check` now also evaluates a home-manager configuration and validates the rendered plugins.
+- **Conventions**: add a short "Plugin pattern" subsection next to "Program module pattern", showing a minimal `dotfiles.ai.plugins.<name>` declaration and pointing at `home/lib/ai/CLAUDE.md` for detail.
+
+- [ ] **Step 3: Verify the described structure matches reality**
+
+```bash
+ls home/lib/ai/plugins checks
+grep -n "skillsDirs" home/lib/ai/CLAUDE.md
+```
+
+Expected: the directory listings match what the docs claim, and `skillsDirs` appears only where it is described as the Codex/Cursor-internal flattening argument — not as a module option.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md home/lib/ai/CLAUDE.md
+git commit -m "docs: describe the plugin structure
+
+Bean: dotfiles-6qk2"
+```

--- a/.beans/dotfiles-75un--generalise-task-implementer-away-from-beans.md
+++ b/.beans/dotfiles-75un--generalise-task-implementer-away-from-beans.md
@@ -1,0 +1,22 @@
+---
+# dotfiles-75un
+title: Generalise task-implementer away from beans
+status: todo
+type: feature
+priority: low
+created_at: 2026-08-02T12:18:09Z
+updated_at: 2026-08-02T12:18:24Z
+blocked_by:
+    - dotfiles-zo7y
+---
+
+`task-implementer` drives the full implement → review → land loop but is written against beans specifically (bean ids, `beans update` calls, `beans next`). That coupling is why it and `whats-next` stayed in this repository's `.claude/skills/` when the beans hooks became the `df-beans` plugin: shipping `whats-next` globally without `task-implementer` would break its handoff in other repositories.
+
+Split it into a tracker-agnostic core plus a beans-specific variant, then move both skills into plugins:
+
+- the generic implementation loop (branch, implement, subagent review, user review, PR with auto-merge) belongs in `df-base`, working from a plain task description
+- the beans-specific parts (resolving a bean id, status transitions, the `Bean:` commit trailer, `beans next` handoff) belong in `df-beans`, alongside `whats-next`
+
+Once that lands, `df-beans` carries skills as well as hooks, and this repository's `.claude/skills/` can be emptied.
+
+Blocked on the plugin epic landing first (dotfiles-zo7y).

--- a/.beans/dotfiles-8ici--validate-rendered-plugins-in-ci.md
+++ b/.beans/dotfiles-8ici--validate-rendered-plugins-in-ci.md
@@ -1,0 +1,104 @@
+---
+# dotfiles-8ici
+title: Validate rendered plugins in CI
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-02T12:18:09Z
+updated_at: 2026-08-02T12:18:09Z
+parent: dotfiles-gq4t
+blocked_by:
+    - dotfiles-36nb
+---
+
+Claude Code owns the plugin manifest schema, so an upgrade could reject a manifest this repo generates. Without a check, the symptom is silent: the plugin simply stops loading and the skills disappear from sessions. `claude plugin validate` runs offline against a directory (verified: exit 0, warning-only output for a minimal manifest), so it works inside a Nix build sandbox.
+
+**Files:**
+- Modify: `flake.nix`
+
+- [ ] **Step 1: Add the check builder**
+
+Insert after `mkHomeEvalCheck` in the same `let` block:
+
+```nix
+      # Runs Claude Code's own manifest validator over every rendered plugin, so a
+      # schema change in a claude-code upgrade fails CI instead of silently
+      # disabling a plugin. `claude plugin validate` needs no network; HOME is set
+      # because it reads user config paths on startup.
+      mkPluginValidateCheck =
+        system:
+        let
+          pkgs = nixOsPkgs { inherit system; };
+          hm = mkHomeManagerSystem {
+            inherit system;
+            user = "check";
+            directory = "/home/check";
+            home = ./checks/home-eval.nix;
+          };
+          pluginPaths = lib.mapAttrsToList (_: entry: entry.source) (
+            lib.filterAttrs (
+              target: _: lib.hasPrefix ".claude/skills/df-" target
+            ) hm.config.home.file
+          );
+        in
+        pkgs.runCommandLocal "plugin-validate" { nativeBuildInputs = [ pkgs.claude-code ]; } ''
+          export HOME=$TMPDIR
+          for plugin in ${lib.escapeShellArgs pluginPaths}; do
+            echo "validating $plugin"
+            claude plugin validate "$plugin"
+          done
+          touch $out
+        '';
+```
+
+`lib` is not otherwise bound at this level in `flake.nix` — use `inputs.nixpkgs.lib` if the bare `lib` does not resolve, matching how the file already reaches for `inputs.nixpkgs.lib.modules.importApply`.
+
+- [ ] **Step 2: Wire it into `checks`**
+
+```nix
+          x86_64-linux =
+            self.packages.x86_64-linux
+            // linuxPkgs.dotfiles.internal.rustChecks
+            // {
+              nixfmt = mkNixfmtCheck linuxPkgs;
+              home-eval = mkHomeEvalCheck "x86_64-linux";
+              plugin-validate = mkPluginValidateCheck "x86_64-linux";
+            };
+```
+
+- [ ] **Step 3: Verify the check passes**
+
+Run: `nix build .#checks.x86_64-linux.plugin-validate --no-link -L`
+
+Expected: the log shows one `validating /nix/store/...-plugin-cc-df-base` line per plugin (three of them), each followed by `✔ Validation passed`, and the build succeeds.
+
+- [ ] **Step 4: Verify the check catches a bad manifest**
+
+In `home/lib/ai/plugins/default.nix`, temporarily give the manifest an invalid name — plugin names must be kebab-case with no spaces:
+
+```nix
+          name = "not a valid name";
+```
+
+Run: `nix build .#checks.x86_64-linux.plugin-validate --no-link -L`
+
+Expected: FAIL, with validation errors naming the offending field. Revert the edit and re-run to confirm it passes again.
+
+- [ ] **Step 5: Verify the full flake check**
+
+Run: `nix flake check`
+
+Expected: passes, now covering nixfmt, the Rust workspace, packages, `home-eval` and `plugin-validate`.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+nixfmt flake.nix
+git add flake.nix
+git commit -m "flake: validate rendered plugins in CI
+
+Runs claude plugin validate over each rendered plugin so manifest schema
+drift fails the build rather than silently disabling a plugin.
+
+Bean: dotfiles-8ici"
+```

--- a/.beans/dotfiles-d6t2--add-home-eval-flake-check.md
+++ b/.beans/dotfiles-d6t2--add-home-eval-flake-check.md
@@ -1,0 +1,125 @@
+---
+# dotfiles-d6t2
+title: Add home-eval flake check
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-02T12:11:24Z
+updated_at: 2026-08-02T12:12:12Z
+parent: dotfiles-6f5q
+---
+
+`nix flake check` currently never evaluates anything under `home/`, so module errors and failed assertions are invisible to CI. This check evaluates a home-manager configuration with the AI-assistant modules enabled and fails when an assertion does not hold. Every later task in this epic uses it as its verification command.
+
+It is eval-only: it forces `config.assertions` and the *names* of `config.home.file`, so no program derivations are built and the check stays fast.
+
+**Files:**
+- Create: `checks/home-eval.nix`
+- Modify: `flake.nix` (add `mkHomeEvalCheck` beside `mkNixfmtCheck` around line 224; add the check to `checks.x86_64-linux` around line 276)
+
+- [ ] **Step 1: Create the check's home-manager module**
+
+`checks/home-eval.nix`:
+
+```nix
+# Minimal home-manager configuration for the `home-eval` flake check. Enables the
+# AI-assistant modules so their assertions and `home.file` mappings are evaluated
+# in CI. Never activated on a real machine.
+{
+  home.stateVersion = "26.05";
+
+  dotfiles.programs = {
+    claude-code.enable = true;
+    codex.enable = true;
+    cursor.enable = true;
+    beans = {
+      enable = true;
+      enableClaudeCodeIntegration = true;
+    };
+    plannotator = {
+      claude-code.enable = true;
+      codex.enable = true;
+    };
+  };
+}
+```
+
+- [ ] **Step 2: Add the check builder to `flake.nix`**
+
+Insert directly after the `mkNixfmtCheck` binding (it ends with a `touch $out` heredoc around line 235), still inside the same `let`. Note the deliberate absence of any shell step — `writeText` keeps the check pure evaluation:
+
+```nix
+      # Evaluates a home-manager configuration built from `home/` and fails when any
+      # module assertion does not hold. Eval-only: forces `config.assertions` and the
+      # `home.file` attribute names, so no program derivations are built.
+      mkHomeEvalCheck =
+        system:
+        let
+          pkgs = nixOsPkgs { inherit system; };
+          hm = mkHomeManagerSystem {
+            inherit system;
+            user = "check";
+            directory = "/home/check";
+            home = ./checks/home-eval.nix;
+          };
+          failed = builtins.filter (a: !a.assertion) hm.config.assertions;
+        in
+        if failed != [ ] then
+          throw ''
+            home-eval: assertions failed:
+            ${pkgs.lib.concatLines (builtins.map (a: a.message) failed)}''
+        else
+          pkgs.writeText "home-eval" (pkgs.lib.concatLines (builtins.attrNames hm.config.home.file));
+```
+
+- [ ] **Step 3: Wire it into `checks`**
+
+In the `checks` attribute, extend the `x86_64-linux` set. Leave `aarch64-darwin` alone: `mkHomeManagerSystem` calls `nixOsPkgs` regardless of system, so a darwin variant would evaluate against the non-darwin package set.
+
+```nix
+          x86_64-linux =
+            self.packages.x86_64-linux
+            // linuxPkgs.dotfiles.internal.rustChecks
+            // {
+              nixfmt = mkNixfmtCheck linuxPkgs;
+              home-eval = mkHomeEvalCheck "x86_64-linux";
+            };
+```
+
+- [ ] **Step 4: Verify the check passes on the current tree**
+
+Run: `nix build .#checks.x86_64-linux.home-eval --no-link --print-out-paths`
+
+Expected: a store path is printed. `cat` that path to see the list of `home.file` targets — it should include `.claude/settings.json` and `.claude/skills/brainstorming`.
+
+- [ ] **Step 5: Verify the check actually catches a failure**
+
+Prove the harness works before trusting it. In `home/programs/claude-code/default.nix`, temporarily replace the body of the `assertions = [ ... ];` list with:
+
+```nix
+    assertions = [
+      {
+        assertion = false;
+        message = "deliberate home-eval harness probe";
+      }
+    ];
+```
+
+Run: `nix build .#checks.x86_64-linux.home-eval --no-link`
+
+Expected: FAIL, with `error: home-eval: assertions failed:` followed by `deliberate home-eval harness probe`.
+
+Revert with `git checkout home/programs/claude-code/default.nix`, then re-run the build and confirm it passes again.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+nixfmt flake.nix checks/home-eval.nix
+git add flake.nix checks/home-eval.nix
+git commit -m "flake: add home-eval check
+
+Evaluates a home-manager configuration from home/ and fails on any module
+assertion, giving CI its first coverage of the home-manager modules.
+
+Bean: dotfiles-d6t2"
+```

--- a/.beans/dotfiles-d7u9--add-the-plugin-renderer-mkpluginfiles.md
+++ b/.beans/dotfiles-d7u9--add-the-plugin-renderer-mkpluginfiles.md
@@ -1,0 +1,258 @@
+---
+# dotfiles-d7u9
+title: Add the plugin renderer (mkPluginFiles)
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-02T12:14:11Z
+updated_at: 2026-08-02T12:14:11Z
+parent: dotfiles-jali
+blocked_by:
+    - dotfiles-lnd7
+---
+
+The renderer: turns a `dotfiles.ai.plugins` declaration into a Claude Code skills-directory plugin directory. Mirrors `home/lib/ai/skills/default.nix`, reusing the same `process-frontmatter` tool for variant filtering and the same skill-discovery helper.
+
+Layout produced per plugin (verified against Claude Code 2.1.220):
+
+```
+df-<name>/
+  .claude-plugin/plugin.json
+  skills/<skill>/SKILL.md       + any supporting files
+  hooks/hooks.json              only when hooks are declared
+```
+
+**Files:**
+- Create: `home/lib/ai/plugins/default.nix`
+- Modify: `home/lib/ai/skills/default.nix` (export the existing private `readSkillDir`)
+
+- [ ] **Step 1: Export `readSkillDir` from the skills library**
+
+`home/lib/ai/skills/default.nix` defines `readSkillDir` in its `let` block. Leave the definition alone and add it to the returned attribute set, next to `builtinSkillsDir`:
+
+```nix
+{
+  # Path to the built-in skills directory, for consumers to include in skillsDirs.
+  builtinSkillsDir = ./.;
+
+  # Exported so the plugin renderer discovers skills the same way.
+  inherit readSkillDir;
+```
+
+- [ ] **Step 2: Write the renderer**
+
+`home/lib/ai/plugins/default.nix`:
+
+```nix
+# Renders `dotfiles.ai.plugins` declarations into Claude Code skills-directory
+# plugins. A plugin folder under ~/.claude/skills containing
+# `.claude-plugin/plugin.json` is discovered in place as `<name>@skills-dir`, with
+# no marketplace and no install step.
+{ lib, pkgs }:
+let
+  inherit (import ../tools { inherit pkgs; }) processFrontmatter;
+  inherit (import ../skills { inherit lib pkgs; }) readSkillDir;
+
+  hookTypes = import ./hook-types.nix { inherit lib; };
+
+  # `claude plugin validate` warns when a manifest has no author.
+  pluginAuthor = {
+    name = "Jamie Brynes";
+  };
+
+  # On-disk plugin names are prefixed so they cannot collide with plugins from
+  # any marketplace. Applied once, here, so the directory name and the
+  # `<name>@skills-dir` id used in settings can never drift apart.
+  prefix = name: "df-${name}";
+
+  # Merge one plugin's skillDirs into { skills, conflicts }. Conflicts are names
+  # defined in more than one of that plugin's directories.
+  collectSkills =
+    skillDirs:
+    builtins.foldl'
+      (
+        acc: dir:
+        let
+          dirSkills = readSkillDir dir;
+          newConflicts = builtins.filter (name: builtins.hasAttr name acc.skills) (
+            builtins.attrNames dirSkills
+          );
+        in
+        {
+          skills = acc.skills // dirSkills;
+          conflicts = acc.conflicts ++ newConflicts;
+        }
+      )
+      {
+        skills = { };
+        conflicts = [ ];
+      }
+      skillDirs;
+
+  mkPlugin =
+    variant: name: plugin:
+    let
+      manifest = pkgs.writeText "plugin.json" (
+        builtins.toJSON {
+          name = prefix name;
+          author = pluginAuthor;
+          inherit (plugin) version description defaultEnabled;
+        }
+      );
+
+      mergedHooks = hookTypes.mergeHooks plugin.hooks;
+      hooksJson = pkgs.writeText "hooks.json" (builtins.toJSON { hooks = mergedHooks; });
+
+      # Copy the whole skill directory, then overwrite SKILL.md with the
+      # variant-filtered version — the same shape as `processSkill` in the skills
+      # library, so supporting files (references/, scripts/) come along.
+      copySkill = skillName: path: ''
+        mkdir -p $out/skills/${skillName}
+        cp -r ${path}/. $out/skills/${skillName}/
+        chmod -R u+w $out/skills/${skillName}
+        ${processFrontmatter}/bin/process-frontmatter ${variant} ${path}/SKILL.md \
+          > $out/skills/${skillName}/SKILL.md
+      '';
+    in
+    pkgs.runCommand "plugin-${variant}-${prefix name}" { } ''
+      mkdir -p $out/.claude-plugin
+      cp ${manifest} $out/.claude-plugin/plugin.json
+      ${lib.concatStrings (lib.mapAttrsToList copySkill (collectSkills plugin.skillDirs).skills)}
+      ${lib.optionalString (mergedHooks != { }) ''
+        mkdir -p $out/hooks
+        cp ${hooksJson} $out/hooks/hooks.json
+      ''}
+    '';
+in
+{
+  # Build plugin directories for home.file.
+  #
+  # Arguments:
+  #   variant: frontmatter variant to keep ("cc", "cursor", or "codex")
+  #   targetDir: directory relative to home (e.g. ".claude/skills")
+  #   plugins: the `dotfiles.ai.plugins` attrset
+  #
+  # Returns:
+  #   files: attrset for home.file
+  #   conflicts: "<plugin>:<skill>" strings for skill names defined twice within
+  #     one plugin (for assertions). Collisions *between* plugins are harmless —
+  #     Claude Code namespaces plugin skills as `<plugin>:<skill>`.
+  mkPluginFiles =
+    {
+      variant,
+      targetDir,
+      plugins,
+    }:
+    let
+      enabled = lib.filterAttrs (_: plugin: plugin.enable) plugins;
+    in
+    {
+      files = lib.mapAttrs' (
+        name: plugin:
+        lib.nameValuePair "${targetDir}/${prefix name}" {
+          source = mkPlugin variant name plugin;
+          recursive = true;
+        }
+      ) enabled;
+
+      conflicts = lib.concatLists (
+        lib.mapAttrsToList (
+          name: plugin: map (skill: "${name}:${skill}") (collectSkills plugin.skillDirs).conflicts
+        ) enabled
+      );
+    };
+}
+```
+
+- [ ] **Step 3: Build a plugin from the renderer directly**
+
+Nothing declares a plugin yet, so exercise the renderer standalone. Run from the repository root:
+
+```bash
+nix build --impure --no-link --print-out-paths --expr '
+  let
+    flake = builtins.getFlake (toString ./.);
+    pkgs = flake.inputs.nixpkgs.legacyPackages.x86_64-linux;
+    plugins = import ./home/lib/ai/plugins/default.nix { inherit (pkgs) lib; inherit pkgs; };
+  in
+  (plugins.mkPluginFiles {
+    variant = "cc";
+    targetDir = ".claude/skills";
+    plugins.probe = {
+      enable = true;
+      description = "probe";
+      version = "0.1.0";
+      defaultEnabled = false;
+      skillDirs = [ ./home/lib/ai/skills ];
+      hooks = { };
+    };
+  }).files.".claude/skills/df-probe".source'
+```
+
+Expected: a store path. Inspect it:
+
+```bash
+ls $(!!)/.claude-plugin $(!!)/skills
+```
+
+Expected: `plugin.json` in the first, and the ten skill directories (`brainstorming`, `coding-effectively`, …) in the second. No `hooks/` directory, since no hooks were declared.
+
+- [ ] **Step 4: Validate the built plugin with Claude Code**
+
+Using the store path from the previous step as `$P`:
+
+```bash
+HOME=$(mktemp -d) claude plugin validate $P
+```
+
+Expected: `✔ Validation passed` with no warnings (the `author` field suppresses the only warning the CLI emits for a minimal manifest).
+
+- [ ] **Step 5: Verify frontmatter filtering actually ran**
+
+```bash
+head -20 $P/skills/comment-cleanup/SKILL.md
+```
+
+Expected: the frontmatter contains no `cc:`, `cursor:` or `codex:` prefixed keys — `process-frontmatter` strips the non-matching ones and unprefixes the rest.
+
+- [ ] **Step 6: Verify hooks render when declared**
+
+Re-run the Step 3 command with `hooks` replaced by:
+
+```nix
+      hooks.probe-hook = {
+        enable = true;
+        event = "SessionStart";
+        matcher = null;
+        hooks = [
+          {
+            type = "command";
+            command = "/bin/true";
+            timeout = null;
+          }
+        ];
+      };
+```
+
+Then: `cat $P/hooks/hooks.json`
+
+Expected: `{"hooks":{"SessionStart":[{"hooks":[{"command":"/bin/true","type":"command"}]}]}}` — the same shape the claude-code module writes into `settings.json` today.
+
+- [ ] **Step 7: Verify eval of the whole config is still clean**
+
+Run: `nix build .#checks.x86_64-linux.home-eval --no-link`
+
+Expected: passes. Nothing consumes the renderer yet, so this only proves the `readSkillDir` export did not break the skills library.
+
+- [ ] **Step 8: Format and commit**
+
+```bash
+nixfmt home/lib/ai/plugins/default.nix home/lib/ai/skills/default.nix
+git add home/lib/ai/plugins/default.nix home/lib/ai/skills/default.nix
+git commit -m "home/lib/ai: add plugin renderer
+
+mkPluginFiles builds one skills-directory plugin per declaration, with a
+manifest, variant-filtered skills and optional hooks.json.
+
+Bean: dotfiles-d7u9"
+```

--- a/.beans/dotfiles-e4zf--declare-df-base-and-wire-assistants-to-plugins.md
+++ b/.beans/dotfiles-e4zf--declare-df-base-and-wire-assistants-to-plugins.md
@@ -1,0 +1,231 @@
+---
+# dotfiles-e4zf
+title: Declare df-base and wire assistants to plugins
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-02T12:17:06Z
+updated_at: 2026-08-02T12:17:06Z
+parent: dotfiles-u1q7
+blocked_by:
+    - dotfiles-d7u9
+---
+
+Declares the first plugin, `df-base`, and makes all three assistant modules consume `dotfiles.ai.plugins`. Claude Code renders real plugin directories; Codex and Cursor flatten the same `skillDirs` through the existing `mkSkillFiles`.
+
+The per-assistant `skillsDirs` options stay in place and keep working in this task, so `plannotator` and `beans` are unaffected. They are removed once every consumer has moved (later task).
+
+After this lands, `brainstorming` is invoked as `df-base:brainstorming` in Claude Code, and unchanged as `brainstorming` in Codex and Cursor.
+
+**Files:**
+- Create: `home/lib/ai/plugins/base.nix` (via `git mv` of the skill-reinforcement hook)
+- Delete: `home/programs/claude-code/hooks/skill-reinforcement.nix`
+- Modify: `home/default.nix`, `home/programs/claude-code/hooks/default.nix`, `home/programs/claude-code/default.nix`, `home/programs/codex/default.nix`, `home/programs/cursor/default.nix`
+
+- [ ] **Step 1: Move the skill-reinforcement module into the plugin library**
+
+```bash
+git mv home/programs/claude-code/hooks/skill-reinforcement.nix home/lib/ai/plugins/base.nix
+```
+
+Then rewrite it as the `df-base` declaration. Keep the `script` binding — the whole `pkgs.writeShellScript "skill-reinforcement-hook" '' ... ''` block — exactly as it is; only the header and the trailing attribute set change:
+
+```nix
+# The `df-base` plugin: the assistant-agnostic skills from `home/lib/ai/skills`
+# plus the hook that reinforces skill activation. Always declared — each assistant
+# module decides whether to render it.
+{ lib, pkgs, ... }:
+let
+  aiSkills = import ../skills { inherit lib pkgs; };
+
+  script = pkgs.writeShellScript "skill-reinforcement-hook" ''
+    ... unchanged, keep the existing heredoc verbatim ...
+  '';
+in
+{
+  dotfiles.ai.plugins.base = {
+    enable = true;
+    description = "Core assistant skills and the skill-activation reinforcement hook";
+    defaultEnabled = true;
+    skillDirs = [ aiSkills.builtinSkillsDir ];
+    hooks.skill-reinforcement = {
+      enable = true;
+      event = "UserPromptSubmit";
+      hooks = [
+        {
+          type = "command";
+          command = "${script}";
+        }
+      ];
+    };
+  };
+}
+```
+
+The old file gated the hook on `config.dotfiles.programs.claude-code.enable`. That gate is gone because rendering is now what gates it: the claude-code module only emits plugin files when it is enabled.
+
+- [ ] **Step 2: Drop the deleted import and add the new one**
+
+`home/programs/claude-code/hooks/default.nix` becomes:
+
+```nix
+{ ... }:
+{
+  imports = [
+    ./debug.nix
+  ];
+}
+```
+
+`home/default.nix` gains `./lib/ai/plugins/base.nix` in `imports`, next to the `./lib/ai/plugins/module.nix` entry added earlier:
+
+```nix
+  imports = [
+    home
+    ./profiles.nix
+    ./lib/ai/plugins/module.nix
+    ./lib/ai/plugins/base.nix
+  ]
+  ++ programs;
+```
+
+- [ ] **Step 3: Render plugins from the claude-code module**
+
+In `home/programs/claude-code/default.nix`, alongside the existing `aiSkills` binding:
+
+```nix
+  aiPlugins = import ../../lib/ai/plugins { inherit lib pkgs; };
+  plugins = aiPlugins.mkPluginFiles {
+    variant = "cc";
+    targetDir = ".claude/skills";
+    plugins = config.dotfiles.ai.plugins;
+  };
+```
+
+In its `config` block, delete this line — `df-base` now owns the built-in skills:
+
+```nix
+    dotfiles.programs.claude-code.skillsDirs = [ aiSkills.builtinSkillsDir ];
+```
+
+Add a second assertion beside the existing one:
+
+```nix
+      {
+        assertion = plugins.conflicts == [ ];
+        message = "claude-code: skill names defined twice within one plugin: ${builtins.concatStringsSep ", " plugins.conflicts}";
+      }
+```
+
+And merge the plugin files into `home.file`:
+
+```nix
+    home.file = {
+      ".claude/CLAUDE.md".source = ../../lib/ai/global-instructions.md;
+      ".claude/settings.json".source = settingsJson;
+    }
+    // skills.files
+    // plugins.files;
+```
+
+- [ ] **Step 4: Add the enabledPlugins option**
+
+Still in `home/programs/claude-code/default.nix`, add an option beside `skillOverrides`:
+
+```nix
+    enabledPlugins = mkOption {
+      type = types.attrsOf types.bool;
+      default = { };
+      description = ''
+        Plugin enablement written to settings.json as `enabledPlugins`, keyed by
+        `<plugin>@<marketplace>` (for example `df-beans@skills-dir`). Left empty by
+        default: each plugin's own `defaultEnabled` carries the global default, and
+        per-project overrides belong in that project's settings.
+      '';
+    };
+```
+
+and extend `settingsJson` with a matching `optionalAttrs`, following the `skillOverrides` pattern:
+
+```nix
+      // lib.optionalAttrs (cfg.enabledPlugins != { }) {
+        inherit (cfg) enabledPlugins;
+      }
+```
+
+- [ ] **Step 5: Flatten plugin skill dirs for Codex and Cursor**
+
+In `home/programs/codex/default.nix`, change the `skills` binding to append the plugins' skill directories to the module's own list:
+
+```nix
+  pluginSkillDirs = lib.concatMap (plugin: plugin.skillDirs) (
+    lib.attrValues (lib.filterAttrs (_: plugin: plugin.enable) config.dotfiles.ai.plugins)
+  );
+  skills = aiSkills.mkSkillFiles {
+    variant = "codex";
+    targetDir = ".codex/skills";
+    skillsDirs = cfg.skillsDirs ++ pluginSkillDirs;
+    # Codex follows symlinked skill directories but ignores symlinked SKILL.md
+    # files, so symlink the directory itself rather than recreating the tree.
+    recursive = false;
+  };
+```
+
+and delete its `dotfiles.programs.codex.skillsDirs = [ aiSkills.builtinSkillsDir ];` line.
+
+Apply the identical change to `home/programs/cursor/default.nix` with `variant = "cursor"`, `targetDir = ".cursor/skills"`, no `recursive` argument, and delete its `dotfiles.programs.cursor.skillsDirs = [ aiSkills.builtinSkillsDir ];` line.
+
+- [ ] **Step 6: Verify eval and inspect the rendered file set**
+
+Run: `nix build .#checks.x86_64-linux.home-eval --no-link --print-out-paths`
+
+Expected: passes. `cat` the resulting path and confirm it contains `.claude/skills/df-base` and no longer contains `.claude/skills/brainstorming`, while `.codex/skills/brainstorming` and `.cursor/skills/brainstorming` are still present.
+
+- [ ] **Step 7: Build the rendered plugin and validate it**
+
+```bash
+nix build --impure --no-link --print-out-paths --expr '
+  let
+    flake = builtins.getFlake (toString ./.);
+    hm = flake.lib.mkHomeManagerSystem {
+      system = "x86_64-linux";
+      user = "check";
+      directory = "/home/check";
+      home = ./checks/home-eval.nix;
+    };
+  in
+  hm.config.home.file.".claude/skills/df-base".source'
+```
+
+Then, with that store path as `$P`:
+
+```bash
+HOME=$(mktemp -d) claude plugin validate $P
+cat $P/hooks/hooks.json
+```
+
+Expected: validation passes, and `hooks.json` contains a `UserPromptSubmit` entry whose command points at the `skill-reinforcement-hook` store path.
+
+- [ ] **Step 8: Confirm discovery end to end**
+
+```bash
+T=$(mktemp -d); mkdir -p $T/.claude/skills
+cp -r $P $T/.claude/skills/df-base
+HOME=$T claude plugin list
+```
+
+Expected: `df-base@skills-dir` listed with `Status: ✔ loaded` (its `defaultEnabled` is `true`). `HOME=$T claude plugin details df-base@skills-dir` should report 10 skills and 1 hook.
+
+- [ ] **Step 9: Format and commit**
+
+```bash
+nixfmt home/lib/ai/plugins/base.nix home/default.nix home/programs/claude-code/default.nix home/programs/claude-code/hooks/default.nix home/programs/codex/default.nix home/programs/cursor/default.nix
+git add -A home/
+git commit -m "home: render built-in skills as the df-base plugin
+
+Claude Code now loads them as df-base@skills-dir with the skill-reinforcement
+hook bundled in; codex and cursor flatten the same declaration into loose
+skills as before.
+
+Bean: dotfiles-e4zf"
+```

--- a/.beans/dotfiles-gq4t--plugin-validation-check-and-docs.md
+++ b/.beans/dotfiles-gq4t--plugin-validation-check-and-docs.md
@@ -1,0 +1,13 @@
+---
+# dotfiles-gq4t
+title: Plugin validation check and docs
+status: todo
+type: feature
+created_at: 2026-08-02T12:10:37Z
+updated_at: 2026-08-02T12:10:37Z
+parent: dotfiles-zo7y
+---
+
+Guards against manifest schema drift on Claude Code upgrades and brings the written context up to date.
+
+**Owns:** the `plugin-validate` flake check, cross-skill reference audit across `home/lib/ai/skills/**/SKILL.md`, `home/lib/ai/CLAUDE.md`, and the root `CLAUDE.md`.

--- a/.beans/dotfiles-jali--plugin-library.md
+++ b/.beans/dotfiles-jali--plugin-library.md
@@ -1,0 +1,13 @@
+---
+# dotfiles-jali
+title: Plugin library
+status: todo
+type: feature
+created_at: 2026-08-02T12:10:37Z
+updated_at: 2026-08-02T12:10:37Z
+parent: dotfiles-zo7y
+---
+
+The reusable machinery: option definitions and the renderer that turns them into plugin directories. No behaviour change on its own — nothing declares a plugin until the next feature.
+
+**Owns:** `home/lib/ai/plugins/hook-types.nix` (moved from `home/programs/claude-code/hooks/types.nix`), `home/lib/ai/plugins/module.nix` (the `dotfiles.ai.plugins.<name>` options), `home/lib/ai/plugins/default.nix` (`mkPluginFiles`), and the shared `readSkillDir` helper lifted out of `home/lib/ai/skills/default.nix`.

--- a/.beans/dotfiles-kvar--audit-cross-skill-references-for-namespacing.md
+++ b/.beans/dotfiles-kvar--audit-cross-skill-references-for-namespacing.md
@@ -1,0 +1,62 @@
+---
+# dotfiles-kvar
+title: Audit cross-skill references for namespacing
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-02T12:18:09Z
+updated_at: 2026-08-02T12:18:09Z
+parent: dotfiles-gq4t
+blocked_by:
+    - dotfiles-e4zf
+---
+
+Claude Code namespaces plugin skills, so `brainstorming` is now invoked as `df-base:brainstorming`. Any skill body that tells the agent to invoke another skill by bare name is now pointing at a name that does not resolve under Claude Code — while remaining correct for Codex and Cursor, which still get flat skills.
+
+**Files:**
+- Modify: whichever files under `home/lib/ai/skills/**/SKILL.md` the audit turns up
+
+- [ ] **Step 1: Find every cross-skill reference**
+
+```bash
+grep -rn -E "(invoke|use|hand off to|handoff to|call) (the )?\`?[a-z-]+\`? skill" home/lib/ai/skills/
+grep -rn -E "Skill\(|skills/[a-z-]+" home/lib/ai/skills/
+```
+
+Known instances to check specifically: `brainstorming/SKILL.md` ends by invoking `writing-plans` and references the local `plannotator:user-code-review` skill; `writing-plans/SKILL.md` refers back to the brainstorming flow.
+
+- [ ] **Step 2: Decide the fix per reference**
+
+For each hit, choose one of:
+
+- **Leave it.** Prose that names a skill descriptively ("the brainstorming flow") needs no change.
+- **Make it variant-specific.** Where the instruction is an actual invocation, the `cc:`-prefixed frontmatter mechanism does not help — it filters frontmatter keys, not body text. Prefer wording that works in both worlds: "invoke the `writing-plans` skill (`df-base:writing-plans` in Claude Code)".
+
+Do not restructure the skills; this is a rename audit only.
+
+- [ ] **Step 3: Verify the rendered skills still parse**
+
+Run: `nix build .#checks.x86_64-linux.plugin-validate --no-link -L`
+
+Expected: passes — validation reads frontmatter, so a malformed edit to a `SKILL.md` header surfaces here.
+
+- [ ] **Step 4: Spot-check one rendered skill**
+
+Build the `df-base` plugin path (as in the earlier tasks) and:
+
+```bash
+grep -n "writing-plans" $P/skills/brainstorming/SKILL.md
+```
+
+Expected: the reference reads as decided in Step 2.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add home/lib/ai/skills
+git commit -m "home/lib/ai: fix cross-skill references for plugin namespacing
+
+Plugin skills are invoked as df-base:<name> under Claude Code.
+
+Bean: dotfiles-kvar"
+```

--- a/.beans/dotfiles-lnd7--add-dotfilesaiplugins-option-namespace.md
+++ b/.beans/dotfiles-lnd7--add-dotfilesaiplugins-option-namespace.md
@@ -1,0 +1,145 @@
+---
+# dotfiles-lnd7
+title: Add dotfiles.ai.plugins option namespace
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-02T12:14:11Z
+updated_at: 2026-08-02T12:14:11Z
+parent: dotfiles-jali
+blocked_by:
+    - dotfiles-nx0d
+---
+
+Declares the `dotfiles.ai.plugins.<name>` option namespace — the single place a feature declares its skills and hooks, replacing today's split between `skillsDirs` on three assistant modules and hand-wired `hooks` entries.
+
+Options only in this task: nothing reads them yet, so there is no behaviour change. The renderer comes next.
+
+**Files:**
+- Create: `home/lib/ai/plugins/module.nix`
+- Modify: `home/default.nix` (add the module to `imports`)
+
+- [ ] **Step 1: Write the options module**
+
+`home/lib/ai/plugins/module.nix`. Note this is a real home-manager module (uses `imports`/`options`), unlike the sibling `default.nix` files under `home/lib/ai/`, which are plain functions:
+
+```nix
+# Option namespace for AI assistant plugins. A plugin bundles skills and hooks
+# under one name that can be enabled or disabled as a unit — globally via
+# `defaultEnabled`, per project via Claude Code's `enabledPlugins` setting.
+#
+# Consumers project these declarations per assistant: claude-code renders real
+# plugin directories, codex and cursor flatten `skillDirs` into loose skills.
+{ lib, ... }:
+let
+  hookTypes = import ./hook-types.nix { inherit lib; };
+
+  pluginType = lib.types.submodule {
+    options = {
+      enable = lib.mkEnableOption "this plugin";
+
+      description = lib.mkOption {
+        type = lib.types.str;
+        description = "Human-readable summary, written to the plugin manifest.";
+      };
+
+      version = lib.mkOption {
+        type = lib.types.str;
+        default = "0.1.0";
+        description = "Plugin version, written to the plugin manifest.";
+      };
+
+      defaultEnabled = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Whether the plugin is active when no `enabledPlugins` entry decides
+          otherwise. Written to the manifest as `defaultEnabled`; any entry in
+          user, project or local settings takes precedence over it.
+        '';
+      };
+
+      skillDirs = lib.mkOption {
+        type = lib.types.listOf lib.types.path;
+        default = [ ];
+        description = "Directories containing <skill>/SKILL.md subdirectories.";
+      };
+
+      hooks = lib.mkOption {
+        type = lib.types.attrsOf hookTypes.hookType;
+        default = { };
+        description = "Named hook definitions, rendered to the plugin's hooks/hooks.json.";
+      };
+    };
+  };
+in
+{
+  options.dotfiles.ai.plugins = lib.mkOption {
+    type = lib.types.attrsOf pluginType;
+    default = { };
+    description = ''
+      AI assistant plugins, keyed by short name. The on-disk plugin name is the
+      key prefixed with `df-`, so `plannotator` installs as `df-plannotator` and
+      is referenced in settings as `df-plannotator@skills-dir`.
+    '';
+  };
+}
+```
+
+- [ ] **Step 2: Import it from the home entrypoint**
+
+`home/default.nix` currently has:
+
+```nix
+  imports = [
+    home
+    ./profiles.nix
+  ]
+  ++ programs;
+```
+
+Change to:
+
+```nix
+  imports = [
+    home
+    ./profiles.nix
+    ./lib/ai/plugins/module.nix
+  ]
+  ++ programs;
+```
+
+It is imported explicitly rather than picked up by the `./programs` scan because it is infrastructure, not a program.
+
+- [ ] **Step 3: Verify the option exists and eval is clean**
+
+Run: `nix build .#checks.x86_64-linux.home-eval --no-link --print-out-paths`
+
+Expected: passes. An option-type error (for example a typo in `lib.types`) fails here.
+
+- [ ] **Step 4: Verify the option accepts a declaration**
+
+Temporarily append to `checks/home-eval.nix`, inside the top-level attribute set:
+
+```nix
+  dotfiles.ai.plugins.probe = {
+    enable = true;
+    description = "probe";
+  };
+```
+
+Run: `nix build .#checks.x86_64-linux.home-eval --no-link`
+
+Expected: passes — proving the submodule accepts a minimal declaration and that `description` is the only required field. Then remove those lines again and re-run to confirm.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+nixfmt home/lib/ai/plugins/module.nix home/default.nix
+git add home/lib/ai/plugins/module.nix home/default.nix
+git commit -m "home/lib/ai: add dotfiles.ai.plugins options
+
+Single declaration point for assistant plugins; no consumers yet.
+
+Bean: dotfiles-lnd7"
+```

--- a/.beans/dotfiles-nx0d--move-hook-types-into-the-plugin-library.md
+++ b/.beans/dotfiles-nx0d--move-hook-types-into-the-plugin-library.md
@@ -1,0 +1,74 @@
+---
+# dotfiles-nx0d
+title: Move hook types into the plugin library
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-02T12:14:11Z
+updated_at: 2026-08-02T12:14:11Z
+parent: dotfiles-jali
+blocked_by:
+    - dotfiles-d6t2
+---
+
+The plugin renderer needs `hookType` and `mergeHooks` to build each plugin's `hooks/hooks.json`, but they currently live inside a program module (`home/programs/claude-code/hooks/types.nix`). A library must not import from a program module, so move the file into `home/lib/ai/plugins/` and repoint the two existing importers.
+
+Pure move — no schema changes, no behaviour change. The `home-eval` check from the previous task is what proves nothing broke.
+
+**Files:**
+- Create: `home/lib/ai/plugins/hook-types.nix` (verbatim copy of the file below)
+- Delete: `home/programs/claude-code/hooks/types.nix`
+- Modify: `home/programs/claude-code/default.nix:23`
+- Modify: `home/programs/claude-code/hooks/debug.nix:10`
+
+- [ ] **Step 1: Move the file**
+
+```bash
+mkdir -p home/lib/ai/plugins
+git mv home/programs/claude-code/hooks/types.nix home/lib/ai/plugins/hook-types.nix
+```
+
+Its contents are unchanged: a `{ lib }` function returning `{ hookEvents, hookCommandType, hookType, mergeHooks }`. Do not edit it in this task.
+
+- [ ] **Step 2: Repoint the claude-code module**
+
+In `home/programs/claude-code/default.nix`, line 23:
+
+```nix
+  hookTypes = import ../../lib/ai/plugins/hook-types.nix { inherit lib; };
+```
+
+- [ ] **Step 3: Repoint the debug hook module**
+
+In `home/programs/claude-code/hooks/debug.nix`, line 10:
+
+```nix
+  hookTypes = import ../../../lib/ai/plugins/hook-types.nix { inherit lib; };
+```
+
+The path has one more `../` than the previous step: this file sits in `home/programs/claude-code/hooks/`.
+
+- [ ] **Step 4: Verify eval still succeeds**
+
+Run: `nix build .#checks.x86_64-linux.home-eval --no-link --print-out-paths`
+
+Expected: passes, printing a store path. A wrong relative path fails here with `error: path '...' does not exist`.
+
+- [ ] **Step 5: Confirm no stale references remain**
+
+Run: `grep -rn "hooks/types.nix" home/`
+
+Expected: no output.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+nixfmt home/lib/ai/plugins/hook-types.nix home/programs/claude-code/default.nix home/programs/claude-code/hooks/debug.nix
+git add -A home/
+git commit -m "home/lib/ai: move hook types into the plugin library
+
+The plugin renderer needs hookType/mergeHooks to build hooks.json, and a
+library must not import from a program module.
+
+Bean: dotfiles-nx0d"
+```

--- a/.beans/dotfiles-u1q7--plugin-inventory-and-module-migration.md
+++ b/.beans/dotfiles-u1q7--plugin-inventory-and-module-migration.md
@@ -1,0 +1,13 @@
+---
+# dotfiles-u1q7
+title: Plugin inventory and module migration
+status: todo
+type: feature
+created_at: 2026-08-02T12:10:37Z
+updated_at: 2026-08-02T12:10:37Z
+parent: dotfiles-zo7y
+---
+
+Declares the three plugins and moves every existing consumer onto them, ending with the removal of the per-assistant `skillsDirs` options so `dotfiles.ai.plugins` is the only entry point.
+
+**Owns:** `home/lib/ai/plugins/module.nix` (the `df-base` declaration), `home/programs/claude-code/default.nix`, `home/programs/claude-code/hooks/skill-reinforcement.nix`, `home/programs/plannotator/default.nix`, `home/programs/beans.nix`, `home/programs/codex/default.nix`, `home/programs/cursor/default.nix`, and this repository's `.claude/settings.json`.

--- a/.beans/dotfiles-vjte--convert-beans-prime-hooks-to-the-df-beans-plugin.md
+++ b/.beans/dotfiles-vjte--convert-beans-prime-hooks-to-the-df-beans-plugin.md
@@ -1,0 +1,117 @@
+---
+# dotfiles-vjte
+title: Convert beans prime hooks to the df-beans plugin
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-02T12:17:06Z
+updated_at: 2026-08-02T12:17:06Z
+parent: dotfiles-u1q7
+blocked_by:
+    - dotfiles-e4zf
+---
+
+Moves the beans `SessionStart`/`PreCompact` prime hooks into a `df-beans` plugin with `defaultEnabled = false`. This is the change the whole epic exists for: today those hooks fire in every project regardless of whether it has a beans database; afterwards they fire only where the plugin is switched on.
+
+The `Bash(beans *)` permission entry stays on the module — plugins cannot carry a permission allowlist, and the entry is inert when the plugin is off.
+
+`task-implementer` and `whats-next` stay in this repository's `.claude/skills/` for now. `whats-next` hands off to `task-implementer`, so shipping one without the other would break that handoff in other repositories. They move once `task-implementer` is generalised (follow-up bean).
+
+**Files:**
+- Modify: `home/programs/beans.nix`
+
+- [ ] **Step 1: Replace the hook wiring with a plugin declaration**
+
+Delete the whole `dotfiles.programs.claude-code.hooks = lib.mkIf cfg.enableClaudeCodeIntegration { ... };` block and put this in its place:
+
+```nix
+    dotfiles.ai.plugins.beans = lib.mkIf cfg.enableClaudeCodeIntegration {
+      enable = true;
+      description = "Primes sessions with the beans issue-tracker workflow";
+      # Off unless a project opts in: these hooks are only useful in a repository
+      # that actually has a beans database.
+      defaultEnabled = false;
+      hooks = {
+        beans-prime-session-start = {
+          enable = true;
+          event = "SessionStart";
+          hooks = [
+            {
+              type = "command";
+              command = "${pkgs.dotfiles.beans}/bin/beans prime";
+            }
+          ];
+        };
+        beans-prime-pre-compact = {
+          enable = true;
+          event = "PreCompact";
+          hooks = [
+            {
+              type = "command";
+              command = "${pkgs.dotfiles.beans}/bin/beans prime";
+            }
+          ];
+        };
+      };
+    };
+```
+
+Leave the `dotfiles.programs.claude-code.permissions.allow` block untouched.
+
+- [ ] **Step 2: Verify eval**
+
+Run: `nix build .#checks.x86_64-linux.home-eval --no-link --print-out-paths`
+
+Expected: passes, and the printed file list contains `.claude/skills/df-beans`.
+
+- [ ] **Step 3: Verify the hooks left settings.json**
+
+```bash
+nix build --impure --no-link --print-out-paths --expr '
+  let
+    flake = builtins.getFlake (toString ./.);
+    hm = flake.lib.mkHomeManagerSystem {
+      system = "x86_64-linux";
+      user = "check";
+      directory = "/home/check";
+      home = ./checks/home-eval.nix;
+    };
+  in
+  hm.config.home.file.".claude/settings.json".source'
+```
+
+Then: `jq '.hooks | keys' $(that path)`
+
+Expected: no `SessionStart` or `PreCompact` entries remain from beans. `jq '.permissions.allow' ...` should still list `"Bash(beans *)"`.
+
+- [ ] **Step 4: Verify the plugin is off by default and can be switched on**
+
+Build the plugin path the same way (`hm.config.home.file.".claude/skills/df-beans".source`), then with it as `$P`:
+
+```bash
+T=$(mktemp -d); mkdir -p $T/.claude/skills
+cp -r $P $T/.claude/skills/df-beans
+HOME=$T claude plugin list
+```
+
+Expected: `df-beans@skills-dir` with `Status: ✘ disabled`.
+
+```bash
+echo '{ "enabledPlugins": { "df-beans@skills-dir": true } }' > $T/.claude/settings.json
+HOME=$T claude plugin list
+```
+
+Expected: the same plugin now reports `Status: ✔ loaded`. This is the per-project switch the epic is built around.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+nixfmt home/programs/beans.nix
+git add home/programs/beans.nix
+git commit -m "home/programs/beans: ship prime hooks as the df-beans plugin
+
+Off by default, so beans priming only runs in projects that opt in rather
+than in every session.
+
+Bean: dotfiles-vjte"
+```

--- a/.beans/dotfiles-zo7y--package-agent-skills-as-claude-code-plugins.md
+++ b/.beans/dotfiles-zo7y--package-agent-skills-as-claude-code-plugins.md
@@ -1,0 +1,18 @@
+---
+# dotfiles-zo7y
+title: Package agent skills as Claude Code plugins
+status: todo
+type: epic
+created_at: 2026-08-02T12:10:20Z
+updated_at: 2026-08-02T12:10:20Z
+---
+
+**Goal:** Bundle skills and hooks into named Claude Code skills-directory plugins (`df-base`, `df-plannotator`, `df-beans`) so they can be enabled and disabled per project.
+
+**Architecture:** A new `dotfiles.ai.plugins.<name>` option namespace (declared in `home/lib/ai/plugins/module.nix`) is the single place features declare skills + hooks. A renderer in `home/lib/ai/plugins/default.nix` builds one derivation per plugin laid out as `.claude-plugin/plugin.json` + `skills/` + `hooks/hooks.json`, installed to `~/.claude/skills/df-<name>/`. Claude Code discovers these in place as `df-<name>@skills-dir` — no marketplace, no install step, no cache invalidation. Codex and Cursor keep today's loose skill fan-out by flattening the same declarations through the existing `mkSkillFiles`.
+
+**Tech Stack:** Nix flakes, home-manager modules, `pkgs.runCommand`, the existing `process-frontmatter` Python tool, Claude Code 2.1.220 plugin CLI.
+
+**Spec:** docs/specs/2026-08-02-agent-plugins.md
+
+All three design assumptions were verified empirically before planning (symlinked-file plugin trees are discovered; `defaultEnabled: false` holds and `enabledPlugins` overrides it; `claude plugin validate` runs offline). See the spec's Validation section.

--- a/docs/specs/2026-08-02-agent-plugins.md
+++ b/docs/specs/2026-08-02-agent-plugins.md
@@ -1,0 +1,254 @@
+# Package agent skills as Claude Code skills-directory plugins
+
+## Problem
+
+`home/lib/ai/skills/default.nix` (`mkSkillFiles`) fans a flat list of skill
+directories out to `~/.claude/skills`, `~/.cursor/skills` and `~/.codex/skills`,
+filtering YAML frontmatter per variant at build time. Feature bundling exists only
+informally: `home/programs/plannotator/default.nix` wires a skill *and* a hook by
+hand, `home/programs/beans.nix` wires hooks *and* a permission entry by hand, and
+neither can be toggled as a unit.
+
+Two consequences motivate this work:
+
+1. **No per-project control.** Home-manager only knows `$HOME`, so every skill and
+   hook is on in every project. The beans `SessionStart`/`PreCompact` prime hooks
+   fire in repositories that have no beans database.
+2. **No bundle abstraction.** Adding a feature that spans a skill plus a hook plus
+   an MCP server means editing three unrelated places per assistant.
+
+Claude Code's **skills-directory plugins** solve both: any folder under a skills
+directory containing `.claude-plugin/plugin.json` loads as `<name>@skills-dir` with
+no marketplace, no install step, and discovery *in place* rather than a copy into
+the plugin cache. Enablement resolves from `defaultEnabled` in the manifest,
+overridable by an `enabledPlugins` entry at any settings scope — including a
+project's `.claude/settings.local.json`.
+
+## Goals
+
+- Group skills, hooks and MCP servers into named plugins declared in one place.
+- Enable and disable those plugins per project.
+- Preserve every property the current setup has: build-time variant frontmatter
+  filtering, Nix-store-pinned hook commands, eval-time conflict assertions, no
+  network access, no interactive install step.
+
+## Non-goals
+
+- **Sharability.** Nothing here is installable by anyone else. A real
+  `.claude-plugin/marketplace.json` can be layered on the same derivations later.
+- **Codex and Cursor plugin packaging.** Both now have plugin formats
+  (`.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`), but Cursor's
+  local-install story is undocumented. They keep consuming the same declarations as
+  today's loose skill fan-out.
+- **Generalising `task-implementer`.** Tracked as a follow-up.
+
+## Design
+
+### Delivery mechanism
+
+Each plugin is installed as `~/.claude/skills/df-<name>/` — the same parent
+directory `mkSkillFiles` already targets — but as a plugin folder rather than a
+bare skill folder:
+
+```
+~/.claude/skills/df-plannotator/
+  .claude-plugin/plugin.json     { name, version, description, author, defaultEnabled }
+  skills/<skill>/SKILL.md        variant-filtered, plus any supporting files
+  hooks/hooks.json               emitted only when hooks are declared
+```
+
+Because discovery is in place, a `home-manager switch` that repoints the symlink is
+live in the next session — no marketplace registration, no cache invalidation, no
+trust prompt, and no new mutable state under `~/.claude/plugins/`.
+
+Skills packaged inside a plugin are namespaced by plugin name: `brainstorming`
+becomes `df-base:brainstorming`. This is accepted, not worked around.
+
+### Nix surface
+
+New option namespace `dotfiles.ai.plugins.<name>`, declared in
+`home/lib/ai/plugins/module.nix` and imported explicitly from the `imports` list in
+`home/default.nix` (it is infrastructure, not a program, so it does not go in the
+auto-discovered `home/programs/` scan):
+
+```nix
+dotfiles.ai.plugins.plannotator = {
+  enable = true;
+  description = "Plan and code review via plannotator";
+  version = "0.1.0";
+  defaultEnabled = true;
+  skillDirs = [ ./skills ];
+  hooks.plannotator-review = {
+    enable = true;
+    event = "PermissionRequest";
+    matcher = "ExitPlanMode";
+    hooks = [
+      { type = "command"; command = "${plannotatorWrapper}/bin/plannotator"; timeout = 345600; }
+    ];
+  };
+};
+```
+
+Option types:
+
+| Option | Type | Default | Notes |
+|---|---|---|---|
+| `enable` | bool | `false` | Whether the plugin is emitted at all |
+| `description` | str | — | Required; written to `plugin.json` |
+| `version` | str | `"0.1.0"` | Written to `plugin.json` |
+| `defaultEnabled` | bool | `true` | Written to `plugin.json`; the global default |
+
+`author` is written by the renderer as a constant, not an option — `claude plugin
+validate` warns when it is absent.
+| `skillDirs` | listOf path | `[ ]` | Directories of `<skill>/SKILL.md` subdirectories |
+| `hooks` | attrsOf hookType | `{ }` | Reuses `home/programs/claude-code/hooks/types.nix` |
+
+Plugins can also carry MCP servers, agents, commands and output styles. None of the
+three plugins below declares any, so those options are deliberately left out of this
+change and added when a consumer exists.
+
+The attribute key is the short name (`plannotator`); the `df-` prefix is
+applied once at render time so the on-disk name and the `enabledPlugins` id cannot
+drift from each other.
+
+`hookType` and `mergeHooks` move from `home/programs/claude-code/hooks/types.nix`
+to `home/lib/ai/plugins/` so the plugin library does not depend on a program module;
+the claude-code module imports them from the new location for its own module-level
+hooks. The move is mechanical — no schema changes.
+
+### Renderer
+
+`home/lib/ai/plugins/default.nix`, sibling to `skills/default.nix`, reusing the
+existing `processFrontmatter` tool and the `readSkillDir` helper (lifted from
+`skills/default.nix` into a shared spot so both call the same implementation).
+
+`mkPluginFiles { variant, targetDir, plugins }` returns `{ files, conflicts }`:
+
+- One `pkgs.runCommand` derivation per enabled plugin, laid out as above. Skills are
+  copied and their `SKILL.md` overwritten with the variant-filtered version, exactly
+  as `processSkill` does today.
+- `hooks/hooks.json` is `{ hooks = mergeHooks cfg.hooks; }`, the same shape the
+  claude-code module writes into `settings.json` today.
+- `files` maps `"${targetDir}/df-${name}"` to the derivation with
+  `recursive = true`.
+- `conflicts` lists skill names that collide *within* a single plugin. Cross-plugin
+  collisions are harmless under Claude Code namespacing.
+
+### Assistant projections
+
+| Assistant | Consumes | Result |
+|---|---|---|
+| Claude Code | `mkPluginFiles { variant = "cc"; targetDir = ".claude/skills"; }` | Plugin folders |
+| Codex | `mkSkillFiles` over `lib.concatMap (p: p.skillDirs)` of enabled plugins | Today's loose skills, unchanged |
+| Cursor | same as Codex, `variant = "cursor"` | Today's loose skills, unchanged |
+
+Codex and Cursor flatten, so their existing cross-directory skill-name conflict
+assertion is kept as-is for them. The per-assistant `skillsDirs` options are removed
+from all three modules; `dotfiles.ai.plugins` is the only entry point.
+
+A new `dotfiles.programs.claude-code.enabledPlugins` option (`attrsOf bool`, default
+`{ }`) writes `enabledPlugins` into the generated `~/.claude/settings.json` for
+forcing a plugin on or off globally. It stays empty by default: `defaultEnabled` in
+each manifest carries the global default, so per-project settings remain the only
+thing that has to be edited by hand.
+
+### Plugin inventory
+
+| Plugin | Contents | `defaultEnabled` |
+|---|---|---|
+| `df-base` | the 10 skills in `home/lib/ai/skills/` + the `skill-reinforcement` `UserPromptSubmit` hook | `true` |
+| `df-plannotator` | the `plannotator-user-code-review` skill + the `PermissionRequest`/`ExitPlanMode` hook | `true` |
+| `df-beans` | the `SessionStart` and `PreCompact` `beans prime` hooks | `false` |
+
+Notes on the inventory:
+
+- `skill-reinforcement` moves from `home/programs/claude-code/hooks/skill-reinforcement.nix`
+  into `df-base`, so it toggles with the skills it reinforces. Today it is
+  unconditional.
+- `df-beans` carries hooks only. `task-implementer` and `whats-next` stay in
+  this repository's `.claude/skills/`, because `whats-next` hands off to
+  `task-implementer` and shipping one without the other would break that handoff in
+  other repositories. They move into the plugin once `task-implementer` is
+  generalised (follow-up).
+- The `Bash(beans *)` permission entry stays in `home/programs/beans.nix` — plugins
+  cannot carry a permission allowlist. It is inert when the plugin is off.
+- `cship`'s statusline and the `debug` hook stay module-level; neither is plugin
+  content.
+- `home/lib/ai/global-instructions.md` and the `skillOverrides` mechanism for muting
+  Anthropic's built-in skills are unchanged.
+
+Because `df-beans` is `defaultEnabled: false`, this repository commits its own
+opt-in to `.claude/settings.json`:
+
+```json
+{ "enabledPlugins": { "df-beans@skills-dir": true } }
+```
+
+### Migration
+
+1. Add `home/lib/ai/plugins/` (module + renderer); move `hookType`/`mergeHooks`
+   into it.
+2. Declare `df-base` in the plugins module itself, sourcing
+   `aiSkills.builtinSkillsDir`; delete `skill-reinforcement.nix`'s module wiring and
+   fold its hook into the plugin.
+3. Convert `home/programs/plannotator/default.nix`: replace its
+   `claude-code.skillsDirs` and `claude-code.hooks.plannotator-review` wiring with a
+   single `dotfiles.ai.plugins.plannotator` block. Its Codex hook stays where it is —
+   the events differ per assistant (`Stop` vs `PermissionRequest`), so it is not
+   plugin content under this design.
+4. Convert `home/programs/beans.nix`: prime hooks move into
+   `dotfiles.ai.plugins.beans`; the permission entry stays.
+5. Rewire claude-code, codex and cursor modules to consume `dotfiles.ai.plugins`;
+   remove their `skillsDirs` options.
+6. Commit `.claude/settings.json` in this repository enabling `df-beans@skills-dir`.
+7. Update `home/lib/ai/CLAUDE.md` and the root `CLAUDE.md` structure section.
+
+## Validation
+
+The three assumptions the design rests on were verified against a hand-written
+plugin folder before planning, using Claude Code 2.1.220 (`defaultEnabled` requires
+2.1.154) and a scratch `HOME`. All three hold:
+
+1. **Symlinked-file plugin trees are discovered.** A plugin laid out as real
+   directories containing symlinks to a read-only source — the exact shape
+   home-manager produces with `recursive = true` — is found, including a symlinked
+   `.claude-plugin/plugin.json`. `claude plugin list` reports it under
+   "Skills-directory plugins (.claude/skills/*)" with `Scope: user`. The
+   `recursive = false` fallback is therefore not needed.
+2. **`defaultEnabled: false` holds, and `enabledPlugins` overrides it.** The plugin
+   listed as `Status: ✘ disabled`; adding `{"enabledPlugins": {"df-probe@skills-dir": true}}`
+   to settings flipped it to `Status: ✔ loaded` with no other change.
+3. **`claude plugin validate` runs offline** against a plugin directory and exits 0
+   (warning only, for a missing `author` field), so it is usable inside a Nix build
+   sandbox. `claude plugin details <name>@skills-dir` additionally prints a component
+   inventory and token cost, useful for eyeballing a built plugin.
+
+Ongoing coverage, given there is no runtime to test:
+
+- Eval-time assertions for within-plugin skill-name collisions (all variants) and
+  cross-plugin flattened collisions (Codex and Cursor only).
+- `claude plugin validate <path>` run over each built plugin derivation as a flake
+  check, so manifest schema drift on a Claude Code upgrade fails CI rather than
+  silently disabling a plugin.
+
+## Risks
+
+- **Skills-dir plugins are a younger surface than marketplace installs.** A Claude
+  Code upgrade could change discovery rules. Escape hatch: the same `mkPlugin`
+  derivations can be listed in a generated `.claude-plugin/marketplace.json` and
+  registered via `extraKnownMarketplaces` with a `directory` source, without changing
+  the plugin bundles themselves.
+- **`enabledPlugins` entries persist per project indefinitely**, so renaming a plugin
+  later strands them. Hence fixing the `df-` prefix now.
+- **Namespacing changes invocation names** (`brainstorming` → `df-base:brainstorming`),
+  which affects muscle memory and any cross-skill references written in skill bodies.
+  Skill files that name other skills need an audit during migration.
+
+## Follow-ups
+
+- Generalise `task-implementer` into a tracker-agnostic core plus a beans-specific
+  variant, then move it and `whats-next` into plugins.
+- Evaluate Codex and Cursor plugin packaging once their local-install paths are
+  verified; the renderer is already parameterised by variant.
+- Add `mcpServers` (and, if wanted, `agents`/`commands`/`outputStyles`) to the plugin
+  options when a plugin needs to ship one.


### PR DESCRIPTION
Planning artifacts only — no behaviour change. Adds the spec and the beans tree for restructuring agent skills into Claude Code skills-directory plugins.

## Why

Skills, hooks and permissions are wired per assistant with no bundle abstraction, and home-manager only knows `$HOME` — so every skill and hook is on in every project. The beans prime hooks fire in repositories with no beans database.

## Approach

Each feature declares one `dotfiles.ai.plugins.<name>` entry (skills + hooks). A renderer builds one directory per plugin — `.claude-plugin/plugin.json`, `skills/`, `hooks/hooks.json` — installed to `~/.claude/skills/df-<name>/`, where Claude Code discovers it in place as `df-<name>@skills-dir`. No marketplace, no install step, no cache to invalidate. `defaultEnabled` sets the global default; a project's `enabledPlugins` entry overrides it. Codex and Cursor flatten the same declarations through the existing `mkSkillFiles`, unchanged.

Three plugins: `df-base` (the shared skills + skill-reinforcement hook, on), `df-plannotator` (skill + review hook, on), `df-beans` (prime hooks, off by default and enabled per project).

## Verified before planning

Against Claude Code 2.1.220 with a scratch `HOME`: symlinked-file plugin trees are discovered (so home-manager's `recursive = true` shape works), `defaultEnabled: false` holds and an `enabledPlugins` entry flips it, and `claude plugin validate` runs offline so it can be a flake check.

Follow-ups: dotfiles-75un

🤖 Generated with [Claude Code](https://claude.com/claude-code)