### PR TITLE
crates beansd: shorten rendered project paths with ~

### DIFF
--- a/.beans/dotfiles-0poj--beansd-use-in-the-rendered-paths-where-applicable.md
+++ b/.beans/dotfiles-0poj--beansd-use-in-the-rendered-paths-where-applicable.md
@@ -1,11 +1,30 @@
 ---
 # dotfiles-0poj
 title: '[beansd] Use "~" in the rendered paths where applicable'
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-07-09T15:46:03Z
-updated_at: 2026-07-09T15:46:03Z
+updated_at: 2026-08-02T13:40:15Z
 ---
 
 This makes the paths shorter and easier to read at a glance
+
+## Summary of Changes
+
+Project paths rendered in the beansd launcher top bar (dropdown rows and the
+active-project detail strip) now collapse $HOME to `~`. The full absolute path
+remains available as a `title` tooltip on each path span.
+
+- Added `tildify(path, home)` in `web/views.rs` — component-wise `strip_prefix`,
+  so a sibling dir sharing a name prefix (`/home/jo-backup`) is not shortened,
+  and only a leading $HOME collapses.
+- `ProjectView` gained a derived `display_path`; `key` stays the verbatim
+  absolute path and remains the lookup key in the `<option value>`, the
+  `hx-get ?active=` poll, and the `hx-vals` heartbeat form.
+- $HOME is resolved once at `Server::bind` and injected via `web::State` rather
+  than read per request, and is canonicalized so it compares against registry
+  keys (which `project_key::resolve` canonicalizes) — without that, a symlinked
+  home directory would silently disable the shortening entirely.
+- Errors, tracing fields and beansctl JSON stay absolute: those are
+  machine-facing, and `ProjectSummary.key` is an RPC wire contract.

--- a/crates/beansd/src/web/mod.rs
+++ b/crates/beansd/src/web/mod.rs
@@ -2,6 +2,7 @@ use crate::daemon::Daemon;
 use crate::registry::Registry;
 use axum::Router;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
@@ -16,6 +17,7 @@ mod test_utils;
 pub(in crate::web) struct State {
     pub(in crate::web) registry: Arc<Mutex<Registry>>,
     pub(in crate::web) daemon: Arc<Daemon>,
+    pub(in crate::web) home: Option<Arc<PathBuf>>,
 }
 
 fn router(state: State) -> Router {
@@ -33,7 +35,11 @@ impl Server {
         daemon: Arc<Daemon>,
         port: u16,
     ) -> anyhow::Result<Self> {
-        let state = State { registry, daemon };
+        let state = State {
+            registry,
+            daemon,
+            home: views::home_dir().map(Arc::new),
+        };
         let router = router(state);
         let addr = SocketAddr::from(([127, 0, 0, 1], port));
         let listener = TcpListener::bind(addr).await?;

--- a/crates/beansd/src/web/routes/api/projects.rs
+++ b/crates/beansd/src/web/routes/api/projects.rs
@@ -16,7 +16,7 @@ async fn start_project(
     }
     let reg = state.registry.lock().await;
     let tmpl = TopBarPartial {
-        projects: project_views(&reg),
+        projects: project_views(&reg, state.home.as_deref().map(|h| h.as_path())),
         active_key: None,
         active_project: None,
     };
@@ -32,7 +32,7 @@ async fn stop_project(
     }
     let reg = state.registry.lock().await;
     let tmpl = TopBarPartial {
-        projects: project_views(&reg),
+        projects: project_views(&reg, state.home.as_deref().map(|h| h.as_path())),
         active_key: None,
         active_project: None,
     };

--- a/crates/beansd/src/web/routes/html/projects.rs
+++ b/crates/beansd/src/web/routes/html/projects.rs
@@ -24,7 +24,7 @@ async fn index(
     axum::extract::State(state): axum::extract::State<State>,
 ) -> impl IntoResponse {
     let reg = state.registry.lock().await;
-    let projects = project_views(&reg);
+    let projects = project_views(&reg, state.home.as_deref().map(|h| h.as_path()));
     let active_project = crate::web::views::resolve_active(&projects, q.project.as_deref());
     let tmpl = IndexTemplate {
         projects,
@@ -52,7 +52,7 @@ async fn topbar_partial(
     axum::extract::State(state): axum::extract::State<State>,
 ) -> impl IntoResponse {
     let reg = state.registry.lock().await;
-    let projects = project_views(&reg);
+    let projects = project_views(&reg, state.home.as_deref().map(|h| h.as_path()));
     let active_project = crate::web::views::resolve_active(&projects, q.active.as_deref());
     let tmpl = TopBarPartial {
         projects,
@@ -73,7 +73,7 @@ mod tests {
     use super::*;
     use crate::registry::{self, Project, ProjectState, Registry};
     use crate::spawner::testing::FakeChildHandle;
-    use crate::web::test_utils::{build_state, empty_state};
+    use crate::web::test_utils::{build_state, empty_state, state_with_home};
     use axum::http::{Request, StatusCode};
     use std::sync::Arc;
     use tokio::sync::Mutex;
@@ -177,6 +177,51 @@ mod tests {
         assert!(
             body.contains(r#"<option value="/tmp/p" selected>"#),
             "active project option should be marked selected"
+        );
+    }
+
+    #[tokio::test]
+    async fn partial_renders_home_paths_with_a_tilde_but_keys_verbatim() {
+        let mut r = Registry::new();
+        registry::test_utils::seed_registry(
+            &mut r,
+            vec![Project::new(
+                "/home/jo/workspace/p".into(),
+                "p".into(),
+                ProjectState::Healthy {
+                    port: 4242,
+                    child: Box::new(FakeChildHandle::new(1)),
+                },
+            )],
+        );
+        let state = state_with_home(Arc::new(Mutex::new(r)), Some("/home/jo"));
+        let app = router().with_state(state);
+        let resp = app
+            .oneshot(
+                Request::get("/partials/topbar?active=/home/jo/workspace/p")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = String::from_utf8(
+            axum::body::to_bytes(resp.into_body(), 64 * 1024)
+                .await
+                .unwrap()
+                .to_vec(),
+        )
+        .unwrap();
+        assert!(
+            body.contains(r#"title="/home/jo/workspace/p">~/workspace/p</span>"#),
+            "path span should show the tilde form with the full path as its tooltip, got: {body}"
+        );
+        assert!(
+            !body.contains(">/home/jo/workspace/p</span>"),
+            "no display span should render the full path as its visible text"
+        );
+        assert!(
+            body.contains(r#"<option value="/home/jo/workspace/p" selected>"#),
+            "the option value must stay the real absolute path"
         );
     }
 

--- a/crates/beansd/src/web/templates/top_bar.html
+++ b/crates/beansd/src/web/templates/top_bar.html
@@ -8,7 +8,7 @@
   {% for p in projects %}
   <option value="{{ p.key.display() }}"{% if Some(p.key.clone()) == active_key %} selected{% endif %}>
     <span class="name">{{ p.display_name }}</span>
-    <span class="path">{{ p.key.display() }}</span>
+    <span class="path" title="{{ p.key.display() }}">{{ p.display_path }}</span>
     <span class="badge {{ p.state }}">{{ p.state }}</span>
   </option>
   {% endfor %}
@@ -16,7 +16,7 @@
 {% if let Some(p) = active_project %}
 <div class="topbar-detail">
   <span class="badge {{ p.state }}">{{ p.state }}</span>
-  <span class="path">{{ p.key.display() }}</span>
+  <span class="path" title="{{ p.key.display() }}">{{ p.display_path }}</span>
   {% if let Some(port) = p.port %}<span class="port">:{{ port }}</span>{% endif %}
 </div>
 {% endif %}

--- a/crates/beansd/src/web/test_utils.rs
+++ b/crates/beansd/src/web/test_utils.rs
@@ -2,17 +2,26 @@ use crate::daemon::Daemon;
 use crate::registry::Registry;
 use crate::supervisor::test_utils::FakeSupervisor;
 use crate::web::State;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
 pub(in crate::web) fn build_state(registry: Arc<Mutex<Registry>>) -> State {
+    state_with_home(registry, None)
+}
+
+pub(in crate::web) fn state_with_home(registry: Arc<Mutex<Registry>>, home: Option<&str>) -> State {
     let supervisor = FakeSupervisor::new(registry.clone());
     let daemon = Arc::new(Daemon {
         registry: registry.clone(),
         supervisor,
         lru_cap: 8,
     });
-    State { registry, daemon }
+    State {
+        registry,
+        daemon,
+        home: home.map(|h| Arc::new(PathBuf::from(h))),
+    }
 }
 
 pub(in crate::web) fn empty_state() -> State {

--- a/crates/beansd/src/web/views.rs
+++ b/crates/beansd/src/web/views.rs
@@ -3,13 +3,23 @@ use std::path::{Path, PathBuf};
 
 #[derive(Clone)]
 pub(in crate::web) struct ProjectView {
+    /// Lookup key in links and form values: must render verbatim, never
+    /// shortened to `display_path`.
     pub(in crate::web) key: PathBuf,
+    pub(in crate::web) display_path: String,
     pub(in crate::web) display_name: String,
     pub(in crate::web) state: &'static str,
     pub(in crate::web) port: Option<u16>,
 }
 
-pub(in crate::web) fn project_views(reg: &Registry) -> Vec<ProjectView> {
+/// Canonicalized to compare against registry keys, which are themselves
+/// canonical (`project_key::resolve`); without it a symlinked `$HOME` would
+/// match nothing and shortening would silently never apply.
+pub(in crate::web) fn home_dir() -> Option<PathBuf> {
+    std::fs::canonicalize(std::env::var_os("HOME")?).ok()
+}
+
+pub(in crate::web) fn project_views(reg: &Registry, home: Option<&Path>) -> Vec<ProjectView> {
     reg.iter()
         .map(|p| {
             let (state, port) = match &p.state {
@@ -20,12 +30,28 @@ pub(in crate::web) fn project_views(reg: &Registry) -> Vec<ProjectView> {
             };
             ProjectView {
                 key: p.key.clone(),
+                display_path: tildify(&p.key, home),
                 display_name: p.display_name.clone(),
                 state,
                 port,
             }
         })
         .collect()
+}
+
+fn tildify(path: &Path, home: Option<&Path>) -> String {
+    let full = || path.display().to_string();
+    let Some(home) = home else { return full() };
+    // An empty `$HOME` has no components, so it strips as a prefix of every
+    // path and would render every project as `~/<full path>`.
+    if !home.is_absolute() {
+        return full();
+    }
+    match path.strip_prefix(home) {
+        Ok(rest) if rest.as_os_str().is_empty() => "~".to_string(),
+        Ok(rest) => format!("~/{}", rest.display()),
+        Err(_) => full(),
+    }
 }
 
 /// Resolves the active project for a given query key. A project is only
@@ -49,10 +75,57 @@ mod tests {
     fn view(key: &str, port: Option<u16>) -> ProjectView {
         ProjectView {
             key: PathBuf::from(key),
+            display_path: key.into(),
             display_name: key.into(),
             state: if port.is_some() { "healthy" } else { "dead" },
             port,
         }
+    }
+
+    #[test]
+    fn tildify_collapses_home_prefix() {
+        let home = PathBuf::from("/home/jo");
+        assert_eq!(
+            tildify(Path::new("/home/jo/workspace/dotfiles"), Some(&home)),
+            "~/workspace/dotfiles"
+        );
+        assert_eq!(tildify(Path::new("/home/jo"), Some(&home)), "~");
+    }
+
+    #[test]
+    fn tildify_only_collapses_a_leading_home() {
+        let home = PathBuf::from("/home/jo");
+        assert_eq!(
+            tildify(Path::new("/srv/home/jo/p"), Some(&home)),
+            "/srv/home/jo/p",
+            "home appearing mid-path is not a prefix"
+        );
+        assert_eq!(
+            tildify(Path::new("/home/jo/home/jo/p"), Some(&home)),
+            "~/home/jo/p",
+            "only the leading occurrence collapses, not every match"
+        );
+    }
+
+    #[test]
+    fn tildify_leaves_paths_outside_home_alone() {
+        let home = PathBuf::from("/home/jo");
+        assert_eq!(tildify(Path::new("/tmp/p"), Some(&home)), "/tmp/p");
+        assert_eq!(
+            tildify(Path::new("/home/jo-backup/p"), Some(&home)),
+            "/home/jo-backup/p",
+            "sibling dir sharing a name prefix is not under home"
+        );
+    }
+
+    #[test]
+    fn tildify_falls_back_without_a_usable_home() {
+        assert_eq!(tildify(Path::new("/home/jo/p"), None), "/home/jo/p");
+        assert_eq!(
+            tildify(Path::new("/home/jo/p"), Some(Path::new(""))),
+            "/home/jo/p",
+            "an empty HOME must not swallow every path"
+        );
     }
 
     #[test]


### PR DESCRIPTION
The launcher top bar rendered every project path in full, which is long and hard to scan at a glance. This collapses `$HOME` to `~` in the two display surfaces — the dropdown row and the active-project detail strip — keeping the full path reachable as a `title` tooltip.

## What changed

- `tildify(path, home)` in `web/views.rs` shortens a path for display. Matching is component-wise via `strip_prefix`, so `/home/jo-backup` is not treated as living under `/home/jo`, and only a *leading* `$HOME` collapses.
- `ProjectView` gained a derived `display_path`. `key` stays the verbatim absolute path.
- `$HOME` is resolved once at `Server::bind` and injected through `web::State` rather than read from the environment per request, which also makes rendering deterministic in tests.
- `$HOME` is canonicalized before comparison. Registry keys are canonical (`project_key::resolve` calls `std::fs::canonicalize`), so without this a symlinked home directory would match nothing and the shortening would silently never apply — the exact case the change exists to serve.

## What deliberately did not change

Lookup keys stay absolute: the `<option value>`, the `hx-get ?active=` poll, the `hx-vals` heartbeat form, and the `onchange` `location.assign`. These identify the project to `resolve_active`; shortening them would break project selection.

Errors, `tracing` fields and `beansctl` JSON also stay absolute — they are machine-facing, and `ProjectSummary.key` is an RPC wire contract.

## Testing

Unit tests cover the interesting branches of `tildify`: under home, exactly home, sibling name-prefix, `$HOME` mid-path, leading-occurrence-only, and both degenerate-`$HOME` fallbacks. An HTTP-level test renders the partial against a fixed `/home/jo` home and asserts both halves of the invariant — the span shows `~/workspace/p`, the option value stays `/home/jo/workspace/p`.

`nix flake check` gates apply: `cargo fmt --check`, `clippy -D warnings`, and `cargo nextest run --workspace` all pass locally.

Follow-ups: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)