### PR TITLE
packages: vendor claude-code and sprite from external flakes

### DIFF
--- a/.beans/dotfiles-0i4a--package-update-scripts-swallow-diagnostics-on-fail.md
+++ b/.beans/dotfiles-0i4a--package-update-scripts-swallow-diagnostics-on-fail.md
@@ -1,0 +1,31 @@
+---
+# dotfiles-0i4a
+title: Package update scripts swallow diagnostics on failure
+status: todo
+type: task
+priority: low
+created_at: 2026-08-02T14:01:38Z
+updated_at: 2026-08-02T14:01:38Z
+parent: dotfiles-fo1w
+---
+
+Every `packages/*/update.sh` has an error branch that is unreachable under `set -euo pipefail`:
+
+```bash
+hash=$(nix store prefetch-file --json "$url" 2>/dev/null | jq -r ".hash")
+if [[ -z "$hash" || "$hash" == "null" ]]; then
+  echo "Error: Failed to fetch hash for ${nix_platform}" >&2
+  exit 1
+fi
+```
+
+The pipeline failing aborts the script before the check runs, and `2>/dev/null` has already discarded the real message from curl/nix. In the nightly `auto-update` workflow this surfaces as a bare non-zero exit with no diagnostics.
+
+Affects `beans`, `claude-code`, `codex`, `cship`, `plannotator`, `sprite` — fix consistently across all six.
+
+## Todo
+
+- [ ] Replace the dead branches with `if ! out=$(...); then ...; fi` and stop discarding stderr
+- [ ] Consider a `curl -sfI` HEAD check on one artifact in `packages/claude-code/update.sh` — the GCS manifest can be published before the binaries finish uploading, producing a green update PR whose `nix flake check` fails
+
+Raised in review of dotfiles-j5ab.

--- a/.beans/dotfiles-35eb--sprite-updatesh-distinguish-a-missing-stable-chann.md
+++ b/.beans/dotfiles-35eb--sprite-updatesh-distinguish-a-missing-stable-chann.md
@@ -1,0 +1,20 @@
+---
+# dotfiles-35eb
+title: 'sprite update.sh: distinguish a missing stable channel from a transient failure'
+status: todo
+type: task
+priority: low
+created_at: 2026-08-02T14:01:42Z
+updated_at: 2026-08-02T14:01:42Z
+parent: dotfiles-fo1w
+---
+
+https://sprites-binaries.t3.storage.dev/client/release.txt currently 404s, so `packages/sprite/update.sh` always falls through to the rc channel — the fallback is the happy path today, not the error path.
+
+Once sprite ships a stable release, a transient 5xx on `release.txt` will silently downgrade `hashes.json` from the stable version back to an rc, and nothing in the script or the workflow compares version ordering to catch it.
+
+## Todo
+
+- [ ] Only fall back to `rc.txt` on an HTTP 404; treat other failures as fatal
+
+Raised in review of dotfiles-j5ab.

--- a/.beans/dotfiles-8ici--validate-rendered-plugins-in-ci.md
+++ b/.beans/dotfiles-8ici--validate-rendered-plugins-in-ci.md
@@ -5,7 +5,7 @@ status: todo
 type: task
 priority: normal
 created_at: 2026-08-02T12:18:09Z
-updated_at: 2026-08-02T12:18:09Z
+updated_at: 2026-08-02T13:59:31Z
 parent: dotfiles-gq4t
 blocked_by:
     - dotfiles-36nb
@@ -41,7 +41,7 @@ Insert after `mkHomeEvalCheck` in the same `let` block:
             ) hm.config.home.file
           );
         in
-        pkgs.runCommandLocal "plugin-validate" { nativeBuildInputs = [ pkgs.claude-code ]; } ''
+        pkgs.runCommandLocal "plugin-validate" { nativeBuildInputs = [ pkgs.dotfiles.claude-code ]; } ''
           export HOME=$TMPDIR
           for plugin in ${lib.escapeShellArgs pluginPaths}; do
             echo "validating $plugin"

--- a/.beans/dotfiles-j5ab--bring-claude-code-and-sprites-cli-from-outside-fla.md
+++ b/.beans/dotfiles-j5ab--bring-claude-code-and-sprites-cli-from-outside-fla.md
@@ -1,10 +1,41 @@
 ---
 # dotfiles-j5ab
 title: Bring claude-code and sprites-cli from outside flake into packages/ directory
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-06-06T08:33:47Z
-updated_at: 2026-06-06T08:33:47Z
+updated_at: 2026-08-02T14:01:52Z
 ---
 
+Vendor the two external tool flakes (`claude-code-native-nix`, `sprite-cli-nix`) into `packages/` so they follow the same `default.nix` + `hashes.json` + `update.sh` convention as `codex`/`cship`/`plannotator`, and drop the flake inputs.
+
+## Decisions
+
+- Expose as `pkgs.dotfiles.*` only — no top-level overlay aliases. Downstream system repos referencing `pkgs.sprite` / `pkgs.claude-code` must be updated separately.
+- Delete the `update-flake-inputs` job from `.github/workflows/auto-update.yml`; `update-packages` already loops `packages/*/update.sh`.
+- Package dir named `sprite` to match its `pname`/`mainProgram` (the binary is `sprite`).
+
+## Todo
+
+- [x] Add `packages/claude-code/` (default.nix, hashes.json, update.sh)
+- [x] Add `packages/sprite/` (default.nix, hashes.json, update.sh)
+- [x] Remove `claude-code` and `sprites-cli` flake inputs and their overlays
+- [x] Point `home/programs/claude-code` at `pkgs.dotfiles.claude-code`
+- [x] Delete the `update-flake-inputs` job from auto-update.yml
+- [x] Verify with `nix flake check`
+
+## Summary of Changes
+
+Vendored both external tool flakes into `packages/`, following the existing `default.nix` + `hashes.json` + `update.sh` convention.
+
+- **`packages/claude-code/`** — ported from `github:jamiebrynes7/claude-code-native-nix`. Fetches the prebuilt binary from Anthropic's GCS bucket; `autoPatchelfHook` on Linux, `makeWrapper` sets `CLAUDE_EXECUTABLE_PATH`/`DISABLE_AUTOUPDATER`. `update.sh` reads the release `manifest.json` and converts its hex checksums to SRI, so it needs no downloads.
+- **`packages/sprite/`** — ported from `github:jamiebrynes7/sprite-cli-nix`. `update.sh` prefers the stable channel and falls back to rc; this bumped the pin from `v0.0.1-rc43` to `v0.0.1-rc47`, since the vendored flake was stale.
+- Removed the `claude-code` and `sprites-cli` flake inputs, their overlays, and their transitive `flake-utils`/`systems` lock entries.
+- `home/programs/claude-code` now references `pkgs.dotfiles.claude-code`.
+- Deleted the `update-flake-inputs` job from `.github/workflows/auto-update.yml` — it existed solely to bump these two inputs, and `update-packages` already loops `packages/*/update.sh`.
+- Documented the `pkgs.dotfiles.*`-only convention and the vendored-package shape in `CLAUDE.md`.
+
+Verified: `nix flake check` passes; both packages build and run (`claude 2.1.220`, `sprite v0.0.1-rc47`); the `aarch64-darwin` variants evaluate; a home-manager config with `claude-code` enabled evaluates; both `update.sh` scripts are idempotent on re-run.
+
+Follow-ups from review: dotfiles-0i4a, dotfiles-35eb.

--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -10,58 +10,6 @@ permissions:
   pull-requests: write
 
 jobs:
-  update-flake-inputs:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ vars.POPPET_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.POPPET_BOT_PRIVATE_KEY }}
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          fetch-depth: 0
-
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v21
-
-      - name: Update flake inputs
-        run: nix flake update claude-code sprites-cli
-
-      - name: Check for changes
-        id: check
-        run: |
-          if git diff --quiet -- flake.lock; then
-            echo "update_needed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "update_needed=true" >> "$GITHUB_OUTPUT"
-            echo "timestamp=$(date -u +%Y-%m-%dT%H-%M-%SZ)" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Create Pull Request
-        if: steps.check.outputs.update_needed == 'true'
-        id: create-pr
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          commit-message: "flake.lock: update inputs"
-          title: "flake.lock: update inputs"
-          body: |
-            Updates pinned flake inputs (claude-code, sprites-cli).
-          branch: update-flake-inputs-${{ steps.check.outputs.timestamp }}
-          delete-branch: true
-
-      - name: Merge Pull Request
-        if: steps.check.outputs.update_needed == 'true' && steps.create-pr.outputs.pull-request-number
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} --auto --rebase --delete-branch
-
   update-packages:
     runs-on: ubuntu-latest
     steps:
@@ -108,7 +56,7 @@ jobs:
           commit-message: "packages: update versions"
           title: "packages: update versions"
           body: |
-            Updates `hashes.json` for each package under `packages/` to its latest GitHub release.
+            Updates `hashes.json` for each package under `packages/` to its latest upstream release.
           branch: update-packages-${{ steps.check.outputs.timestamp }}
           delete-branch: true
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,16 @@ templates/
   systems/           # darwin, nixos, home-manager
 modules/             # Shared NixOS/nix-darwin modules (currently empty)
 crates/              # Rust workspace: beansd + beansctl + beansd-rpc — see crates/CLAUDE.md
-packages/            # Nix packages built from this repo (e.g. beans-daemon)
+packages/            # Nix packages — built from this repo (beans-daemon) or vendored upstream binaries
 ```
 
 ## Conventions
+
+### Packages
+
+Every directory under `packages/` is auto-discovered by `flake.nix` and exposed as `pkgs.dotfiles.<dir>` — **only** there, never as a top-level `pkgs.<name>`. Reference them as `pkgs.dotfiles.claude-code`, not `pkgs.claude-code`.
+
+Vendored upstream binaries (`claude-code`, `codex`, `cship`, `plannotator`, `sprite`) follow a fixed shape: a `hashes.json` recording the version plus a per-platform artifact name and hash, a `default.nix` that reads it, and an `update.sh` that refreshes it. `update.sh` must be idempotent — re-running it when the recorded version already matches should exit 0 without touching `hashes.json`, since `.github/workflows/auto-update.yml` runs every script nightly and opens a PR only if `packages/` changed.
 
 ### Program module pattern
 

--- a/flake.lock
+++ b/flake.lock
@@ -38,27 +38,6 @@
         "type": "github"
       }
     },
-    "claude-code": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1784948327,
-        "narHash": "sha256-/nWZMgymaqlfdiqI2nwpLuGhuLp1ZeOBvKdZoWOwBbQ=",
-        "owner": "jamiebrynes7",
-        "repo": "claude-code-native-nix",
-        "rev": "2e68ce7ac5aa0980d4d2964e071f37d7a99c439a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "jamiebrynes7",
-        "repo": "claude-code-native-nix",
-        "type": "github"
-      }
-    },
     "crane": {
       "locked": {
         "lastModified": 1780532242,
@@ -110,42 +89,6 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -220,14 +163,12 @@
     "root": {
       "inputs": {
         "alacritty-themes": "alacritty-themes",
-        "claude-code": "claude-code",
         "crane": "crane",
         "darwin": "darwin",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
         "nixpkgs-darwin": "nixpkgs-darwin",
-        "rust-overlay": "rust-overlay",
-        "sprites-cli": "sprites-cli"
+        "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
@@ -247,57 +188,6 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "sprites-cli": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775191877,
-        "narHash": "sha256-6LLjSbWC+/ltE7eNQM1wx/6pI97d9NiaeRx7EzQVhhI=",
-        "owner": "jamiebrynes7",
-        "repo": "sprite-cli-nix",
-        "rev": "63018fea4fbea4fb38d33e1a54168e3423b872f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "jamiebrynes7",
-        "repo": "sprite-cli-nix",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -25,16 +25,6 @@
     # crane is nixpkgs-agnostic (no `nixpkgs` input to follow); it reads pkgs
     # from `crane.mkLib pkgs` at call sites.
     crane.url = "github:ipetkov/crane";
-
-    # Tools
-    claude-code = {
-      url = "github:jamiebrynes7/claude-code-native-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    sprites-cli = {
-      url = "github:jamiebrynes7/sprite-cli-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs =
@@ -66,8 +56,6 @@
 
       defaultOverlays = [
         inputs.alacritty-themes.overlays.default
-        inputs.claude-code.overlays.default
-        inputs.sprites-cli.overlays.default
         dotfilesOverlay
         (import ./crates { inherit inputs; })
       ];

--- a/home/programs/claude-code/default.nix
+++ b/home/programs/claude-code/default.nix
@@ -17,7 +17,7 @@ let
   claudeWrapper = pkgs.writeShellScript "claude-wrapper" ''
     ${cfg.extraScript}
     export BASH_MAX_TIMEOUT_MS=1800000
-    exec ${pkgs.claude-code}/bin/claude "$@"
+    exec ${pkgs.dotfiles.claude-code}/bin/claude "$@"
   '';
 
   hookTypes = import ./hooks/types.nix { inherit lib; };

--- a/packages/claude-code/default.nix
+++ b/packages/claude-code/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  makeWrapper,
+}:
+
+let
+  release = builtins.fromJSON (builtins.readFile ./hashes.json);
+  version = release.version;
+  platform = release.platforms.${stdenv.hostPlatform.system};
+
+  # Anthropic publishes the native binaries to a fixed GCS bucket rather than a
+  # GitHub release, so the bucket id is part of the URL.
+  gcsBase = "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases";
+in
+stdenv.mkDerivation {
+  pname = "claude-code";
+  inherit version;
+
+  src = fetchurl {
+    url = "${gcsBase}/${version}/${platform.artifact}/claude";
+    hash = platform.hash;
+  };
+
+  # The artifact is a bare executable, not an archive.
+  dontUnpack = true;
+  dontBuild = true;
+  # Without this the Linux binary strips down to just Bun's runtime.
+  dontStrip = true;
+
+  nativeBuildInputs = [ makeWrapper ] ++ lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+
+  buildInputs = lib.optionals stdenv.isLinux [ stdenv.cc.cc.lib ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 $src $out/libexec/claude
+
+    # `$HOME` is deliberately left unexpanded — the CLI expands
+    # CLAUDE_EXECUTABLE_PATH itself. DISABLE_AUTOUPDATER stops it trying to
+    # overwrite itself in the read-only store.
+    makeWrapper $out/libexec/claude $out/bin/claude \
+      --set CLAUDE_EXECUTABLE_PATH '$HOME/.local/bin/claude' \
+      --set DISABLE_AUTOUPDATER 1
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Claude Code - AI-powered command line interface";
+    homepage = "https://code.claude.com";
+    license = licenses.unfree;
+    mainProgram = "claude";
+    platforms = builtins.attrNames release.platforms;
+  };
+}

--- a/packages/claude-code/hashes.json
+++ b/packages/claude-code/hashes.json
@@ -1,0 +1,21 @@
+{
+  "version": "2.1.220",
+  "platforms": {
+    "aarch64-darwin": {
+      "artifact": "darwin-arm64",
+      "hash": "sha256-it3IV/P+ZNWgNor57lAyG1CvtKaRi6PvAYq4T1274IE="
+    },
+    "x86_64-darwin": {
+      "artifact": "darwin-x64",
+      "hash": "sha256-3Ke+CqfT2SSDbUQODG2OPUfvPI5h+lgJtUuQFxcM4vM="
+    },
+    "aarch64-linux": {
+      "artifact": "linux-arm64",
+      "hash": "sha256-FZ5KUdeW878UZ3V3EA9++4RWEbHOrwwwy9jUZQ2UIYU="
+    },
+    "x86_64-linux": {
+      "artifact": "linux-x64",
+      "hash": "sha256-Z09h8g/zBvMQDPkgDkw2xLcCeLW+8ohFSYGblCqJyGM="
+    }
+  }
+}

--- a/packages/claude-code/update.sh
+++ b/packages/claude-code/update.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GCS_BASE="https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases"
+
+declare -A PLATFORM_MAP=(
+  ["aarch64-darwin"]="darwin-arm64"
+  ["x86_64-darwin"]="darwin-x64"
+  ["aarch64-linux"]="linux-arm64"
+  ["x86_64-linux"]="linux-x64"
+)
+
+# Parse args: optional VERSION positional, optional --force to recompute hashes
+# even when the recorded version already matches.
+FORCE=0
+VERSION=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -f | --force)
+      FORCE=1
+      shift
+      ;;
+    -*)
+      echo "Error: unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      VERSION="$1"
+      shift
+      ;;
+  esac
+done
+
+# Resolve version
+if [[ -z "$VERSION" ]]; then
+  VERSION=$(curl -fsSL "${GCS_BASE}/latest" | tr -d '\r\n')
+  echo "Latest version: ${VERSION}"
+fi
+
+# Skip all hash work when the recorded version already matches (unless --force).
+CURRENT_VERSION=$(jq -r '.version // empty' "${SCRIPT_DIR}/hashes.json" 2>/dev/null || true)
+if [[ "$FORCE" -ne 1 && -n "$CURRENT_VERSION" && "$CURRENT_VERSION" == "$VERSION" ]]; then
+  echo "claude-code already at ${VERSION}, skipping"
+  exit 0
+fi
+
+# The release manifest carries a hex checksum per platform, so no download is
+# needed — convert them to SRI rather than prefetching each binary.
+echo "Fetching manifest for ${VERSION}..."
+MANIFEST=$(curl -fsSL "${GCS_BASE}/${VERSION}/manifest.json")
+
+declare -A HASHES
+for nix_platform in "${!PLATFORM_MAP[@]}"; do
+  release_platform="${PLATFORM_MAP[$nix_platform]}"
+  echo "  ${nix_platform}..."
+  checksum=$(jq -r --arg p "$release_platform" '.platforms[$p].checksum // empty' <<<"$MANIFEST")
+  if [[ -z "$checksum" ]]; then
+    echo "Error: No checksum for ${release_platform} in manifest" >&2
+    exit 1
+  fi
+  HASHES[$nix_platform]=$(nix hash convert --hash-algo sha256 --to sri "$checksum")
+done
+
+# Write hashes.json (single source of truth for default.nix)
+jq -n \
+  --arg version "$VERSION" \
+  --arg ad_platform "${PLATFORM_MAP[aarch64-darwin]}" \
+  --arg ad_hash "${HASHES[aarch64-darwin]}" \
+  --arg xd_platform "${PLATFORM_MAP[x86_64-darwin]}" \
+  --arg xd_hash "${HASHES[x86_64-darwin]}" \
+  --arg al_platform "${PLATFORM_MAP[aarch64-linux]}" \
+  --arg al_hash "${HASHES[aarch64-linux]}" \
+  --arg xl_platform "${PLATFORM_MAP[x86_64-linux]}" \
+  --arg xl_hash "${HASHES[x86_64-linux]}" \
+  '{
+    version: $version,
+    platforms: {
+      "aarch64-darwin": { artifact: $ad_platform, hash: $ad_hash },
+      "x86_64-darwin": { artifact: $xd_platform, hash: $xd_hash },
+      "aarch64-linux": { artifact: $al_platform, hash: $al_hash },
+      "x86_64-linux": { artifact: $xl_platform, hash: $xl_hash }
+    }
+  }' \
+  > "${SCRIPT_DIR}/hashes.json"
+
+echo "Updated claude-code to ${VERSION}"

--- a/packages/sprite/default.nix
+++ b/packages/sprite/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  zlib,
+  libgcc,
+}:
+
+let
+  release = builtins.fromJSON (builtins.readFile ./hashes.json);
+  version = release.version;
+  platform = release.platforms.${stdenv.hostPlatform.system};
+
+  baseUrl = "https://sprites-binaries.t3.storage.dev/client";
+in
+stdenv.mkDerivation {
+  pname = "sprite";
+  inherit version;
+
+  src = fetchurl {
+    url = "${baseUrl}/${version}/sprite-${platform.artifact}.tar.gz";
+    hash = platform.hash;
+  };
+
+  # The tarball holds a single `sprite` binary at its root.
+  sourceRoot = ".";
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+
+  buildInputs = lib.optionals stdenv.isLinux [
+    zlib
+    libgcc.lib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 sprite $out/bin/sprite
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Sprite CLI";
+    homepage = "https://sprites.dev";
+    mainProgram = "sprite";
+    platforms = builtins.attrNames release.platforms;
+  };
+}

--- a/packages/sprite/hashes.json
+++ b/packages/sprite/hashes.json
@@ -1,0 +1,21 @@
+{
+  "version": "v0.0.1-rc47",
+  "platforms": {
+    "aarch64-darwin": {
+      "artifact": "darwin-arm64",
+      "hash": "sha256-L+6siRt0WJMAJw7I8qVLoJgVsX64mGpAcsX/EV8CP20="
+    },
+    "x86_64-darwin": {
+      "artifact": "darwin-amd64",
+      "hash": "sha256-gY0JXp25qIpJ95PqMUuILddOb60zvKpHtwa/K+ijXl0="
+    },
+    "aarch64-linux": {
+      "artifact": "linux-arm64",
+      "hash": "sha256-wX0KbxMOXhq/7W/1TyelsAjbMYf4DM58oMLK7hgVW6w="
+    },
+    "x86_64-linux": {
+      "artifact": "linux-amd64",
+      "hash": "sha256-rwOSHuYmb0DIAbLcS0VW83psvcpLLUUqYhG2njmZy44="
+    }
+  }
+}

--- a/packages/sprite/update.sh
+++ b/packages/sprite/update.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE_URL="https://sprites-binaries.t3.storage.dev/client"
+
+declare -A PLATFORM_MAP=(
+  ["aarch64-darwin"]="darwin-arm64"
+  ["x86_64-darwin"]="darwin-amd64"
+  ["aarch64-linux"]="linux-arm64"
+  ["x86_64-linux"]="linux-amd64"
+)
+
+# Parse args: optional VERSION positional, optional --force to recompute hashes
+# even when the recorded version already matches.
+FORCE=0
+VERSION=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -f | --force)
+      FORCE=1
+      shift
+      ;;
+    -*)
+      echo "Error: unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      VERSION="$1"
+      shift
+      ;;
+  esac
+done
+
+# Resolve version. Sprite publishes a stable channel and an rc channel; prefer
+# stable, but fall back to rc since there may be no stable release yet.
+if [[ -z "$VERSION" ]]; then
+  VERSION=$(curl -fsSL "${BASE_URL}/release.txt" 2>/dev/null | tr -d '\r\n' || true)
+  if [[ -z "$VERSION" ]]; then
+    echo "No release version found, trying rc channel..."
+    VERSION=$(curl -fsSL "${BASE_URL}/rc.txt" 2>/dev/null | tr -d '\r\n' || true)
+  fi
+  if [[ -z "$VERSION" ]]; then
+    echo "Error: Failed to fetch version from release or rc channels" >&2
+    exit 1
+  fi
+  echo "Latest version: ${VERSION}"
+fi
+
+# Skip all hash work when the recorded version already matches (unless --force).
+CURRENT_VERSION=$(jq -r '.version // empty' "${SCRIPT_DIR}/hashes.json" 2>/dev/null || true)
+if [[ "$FORCE" -ne 1 && -n "$CURRENT_VERSION" && "$CURRENT_VERSION" == "$VERSION" ]]; then
+  echo "sprite already at ${VERSION}, skipping"
+  exit 0
+fi
+
+# Fetch hashes
+echo "Fetching hashes for ${VERSION}..."
+declare -A HASHES
+for nix_platform in "${!PLATFORM_MAP[@]}"; do
+  release_platform="${PLATFORM_MAP[$nix_platform]}"
+  url="${BASE_URL}/${VERSION}/sprite-${release_platform}.tar.gz"
+  echo "  ${nix_platform}..."
+  hash=$(nix store prefetch-file --json "$url" 2>/dev/null | jq -r '.hash')
+  if [[ -z "$hash" || "$hash" == "null" ]]; then
+    echo "Error: Failed to fetch hash for ${nix_platform}" >&2
+    exit 1
+  fi
+  HASHES[$nix_platform]="$hash"
+done
+
+# Write hashes.json (single source of truth for default.nix)
+jq -n \
+  --arg version "$VERSION" \
+  --arg ad_platform "${PLATFORM_MAP[aarch64-darwin]}" \
+  --arg ad_hash "${HASHES[aarch64-darwin]}" \
+  --arg xd_platform "${PLATFORM_MAP[x86_64-darwin]}" \
+  --arg xd_hash "${HASHES[x86_64-darwin]}" \
+  --arg al_platform "${PLATFORM_MAP[aarch64-linux]}" \
+  --arg al_hash "${HASHES[aarch64-linux]}" \
+  --arg xl_platform "${PLATFORM_MAP[x86_64-linux]}" \
+  --arg xl_hash "${HASHES[x86_64-linux]}" \
+  '{
+    version: $version,
+    platforms: {
+      "aarch64-darwin": { artifact: $ad_platform, hash: $ad_hash },
+      "x86_64-darwin": { artifact: $xd_platform, hash: $xd_hash },
+      "aarch64-linux": { artifact: $al_platform, hash: $al_hash },
+      "x86_64-linux": { artifact: $xl_platform, hash: $xl_hash }
+    }
+  }' \
+  > "${SCRIPT_DIR}/hashes.json"
+
+echo "Updated sprite to ${VERSION}"


### PR DESCRIPTION
`claude-code` and `sprites-cli` were pinned as flake inputs pointing at standalone repos (`claude-code-native-nix`, `sprite-cli-nix`) that did nothing but wrap a prebuilt binary. This brings both in-tree.

## What changed

- **`packages/claude-code/`** — fetches the prebuilt binary from Anthropic's GCS bucket; `autoPatchelfHook` on Linux, `makeWrapper` sets `CLAUDE_EXECUTABLE_PATH`/`DISABLE_AUTOUPDATER`. Its `update.sh` reads the release `manifest.json` and converts the hex checksums to SRI, so refreshing hashes needs no downloads.
- **`packages/sprite/`** — same shape; `update.sh` prefers the stable channel and falls back to rc. Running it bumped the pin `v0.0.1-rc43` → `v0.0.1-rc47`, since the vendored flake was stale.
- Dropped the two flake inputs, their overlays, and their transitive `flake-utils`/`systems` lock entries.
- `home/programs/claude-code` now uses `pkgs.dotfiles.claude-code`.
- Deleted the `update-flake-inputs` job from `auto-update.yml` — it existed solely to bump these two inputs, and `update-packages` already loops `packages/*/update.sh`.
- Recorded the `pkgs.dotfiles.*`-only convention and the vendored-package shape in `CLAUDE.md`.

## Breaking

Both are exposed as `pkgs.dotfiles.*` only — no top-level `pkgs.claude-code` / `pkgs.sprite` aliases. **Downstream system repos referencing `pkgs.sprite` need updating.**

## Verification

- `nix flake check` passes
- Both packages build and run: `claude 2.1.220`, `sprite version v0.0.1-rc47`
- `aarch64-darwin` variants evaluate
- A home-manager config with `claude-code` enabled evaluates (not covered by CI until dotfiles-d6t2 lands)
- Both `update.sh` scripts are idempotent — re-running leaves `hashes.json` untouched
- claude-code hashes match the upstream flake's `version.json` byte-for-byte

Follow-ups: dotfiles-0i4a, dotfiles-35eb

Bean: dotfiles-j5ab

🤖 Generated with [Claude Code](https://claude.com/claude-code)