### PR TITLE
home/programs/claude-code: disable skill-reinforcement hook by default

### DIFF
--- a/.beans/dotfiles-0i9f--restate-critical-code-reviewer-plainly.md
+++ b/.beans/dotfiles-0i9f--restate-critical-code-reviewer-plainly.md
@@ -1,0 +1,30 @@
+---
+# dotfiles-0i9f
+title: Restate critical-code-reviewer plainly
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-15T15:32:59Z
+updated_at: 2026-08-15T15:33:10Z
+parent: dotfiles-nj63
+blocked_by:
+    - dotfiles-vmit
+---
+
+**File:** `home/lib/ai/skills/critical-code-reviewer/SKILL.md` (203 → ~130 lines)
+
+The adversarial stance **stays** — the model default in review is agreeableness (fewer issues surfaced, severity softened), so the framing counteracts a real tendency. The problem is that it is performed rather than stated, and tuned hard enough to need its own counterweight.
+
+Restate in place, do not delete:
+
+- [ ] "Guilty until proven exceptional" → Assume nothing works until the code demonstrates it does
+- [ ] "Every unhandled Promise will reject at 3 AM" → Unhandled rejections surface in production, not in review
+- [ ] "Structural contempt" → Code organisation reveals thinking; flag it
+- [ ] "Assume the worst intentions and the sloppiest habits" → Read for what the code does, not what it appears to intend
+- [ ] "An insult to the reader" → moves to `house-style-code-comments`
+
+Keep: the diff-scope handoff, the cross-repo PRECONDITION guard (a real boundary, correctly forceful), the `pr-checkout.sh` steps, the four severity tiers, the response format, the subagent-mode note (179).
+
+- [ ] Compress (do not delete) the Slop Detector and Adversarial Lens lists (82–116) by roughly half — they work as recall aids
+- [ ] Keep **both** anti-manufacturing correctives (163, 203) through the rewrite. Drop one only after re-reading real review output and confirming honesty holds without it
+- [ ] Run `nix flake check`

--- a/.beans/dotfiles-8ftf--disable-the-skill-reinforcement-hook-by-default.md
+++ b/.beans/dotfiles-8ftf--disable-the-skill-reinforcement-hook-by-default.md
@@ -1,0 +1,35 @@
+---
+# dotfiles-8ftf
+title: Disable the skill-reinforcement hook by default
+status: completed
+type: task
+priority: normal
+created_at: 2026-08-15T15:32:11Z
+updated_at: 2026-08-15T15:53:59Z
+parent: dotfiles-nj63
+---
+
+**File:** `home/programs/claude-code/hooks/skill-reinforcement.nix:45`
+
+The hook injects a MANDATORY SKILL ACTIVATION SEQUENCE on every `UserPromptSubmit`, forcing a YES/NO verdict on every available skill before any work starts. It duplicates skill selection the harness now does natively from the `description` field, and it costs a wall of "NO — not relevant" reasoning every single turn.
+
+Disable rather than delete, so it is one line from returning if skill discovery under-fires. The mechanism already exists: `hookType.enable` (`hooks/types.nix:41`) is an `mkEnableOption` defaulting to false, and `mergeHooks` (line 64) filters disabled hooks out of `settings.json`.
+
+- [x] Change `enable = true;` to `mkDefault false` (unqualified, matching the file's `with lib;` style)
+- [x] Confirm `lib` is in scope in the module args (it is via `with lib;` — use `mkDefault` consistently with the file style)
+- [x] Run `nix flake check`
+- [x] Verify the rendered `settings.json` for a test build no longer lists the skill-reinforcement command under `UserPromptSubmit`
+
+Re-enable downstream with `dotfiles.programs.claude-code.hooks.skill-reinforcement.enable = true;`.
+
+## Summary of Changes
+
+`home/programs/claude-code/hooks/skill-reinforcement.nix:45` — `enable = true` → `enable = mkDefault false`.
+
+The hook definition is retained in full; only its default flips. `mergeHooks` (`hooks/types.nix:64`) filters disabled hooks out of the generated `settings.json`, so nothing renders under `UserPromptSubmit`.
+
+Verified by evaluating `mergeHooks` both ways: disabled yields `{ }` (no `UserPromptSubmit` key at all), enabled yields the hook entry. A subagent review additionally confirmed end-to-end through `mkHomeManagerSystem` that a host setting `dotfiles.programs.claude-code.hooks.skill-reinforcement.enable = true;` overrides the default and re-renders the hook — `mkDefault` (priority 1000) beats `mkEnableOption`'s 1500 and loses to a host's 100, and the enclosing `mkIf cfg.enable` preserves the inner priority modifier. A plain `enable = false;` would instead collide at priority 100 and fail evaluation, so `mkDefault` is load-bearing.
+
+`nix flake check` passes.
+
+Review notes: an intermediate revision added an explanatory comment above the option and corrected a now-false line in `docs/specs/2026-08-02-agent-plugins.md`. Both were reverted on user review — the comment was an artifact of the change itself, and the spec is a dated historical design artifact rather than living documentation. The rationale lives here and in the commit message instead.

--- a/.beans/dotfiles-e6kx--compress-devils-advocate-reference-files.md
+++ b/.beans/dotfiles-e6kx--compress-devils-advocate-reference-files.md
@@ -1,0 +1,28 @@
+---
+# dotfiles-e6kx
+title: Compress devils-advocate reference files
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-15T15:33:00Z
+updated_at: 2026-08-15T15:33:10Z
+parent: dotfiles-nj63
+blocked_by:
+    - dotfiles-nw9f
+---
+
+**Files:** `home/lib/ai/skills/devils-advocate/` (117 + 1,068 reference lines → ~400 total)
+
+Lowest-confidence item in the epic: the references are already progressively disclosed, so always-loaded cost is only 117 lines. Reduce the exposition, keep the calibration.
+
+Keep untouched:
+
+- [ ] SKILL.md calibration — the 7-concern cap, honest-severity definitions, the "so what?" test, steel-man-first. Calibration is exactly what a model cannot supply for itself
+- [ ] `references/ai-blind-spots.md` (326 lines) — the one reference that is not generic, and the most directly default-counteracting content in the repo
+
+Compress:
+
+- [ ] `references/questioning-frameworks.md` (405 → ~80) — naming pre-mortem, inversion, and Socratic probing carries the value; explaining Five Whys and Six Thinking Hats at length does not
+- [ ] `references/blind-spots.md` (337 → ~80) — keep the 11 categories as a checklist, cut the exposition
+
+- [ ] Run `nix flake check`

--- a/.beans/dotfiles-emaa--trim-coding-effectively-to-rules-without-elaborati.md
+++ b/.beans/dotfiles-emaa--trim-coding-effectively-to-rules-without-elaborati.md
@@ -1,0 +1,43 @@
+---
+# dotfiles-emaa
+title: Trim coding-effectively to rules without elaboration
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-15T15:32:59Z
+updated_at: 2026-08-15T15:33:10Z
+parent: dotfiles-nj63
+blocked_by:
+    - dotfiles-vmit
+---
+
+**File:** `home/lib/ai/skills/coding-effectively/SKILL.md` (191 → ~60 lines, plus a ~25-line reference)
+
+`description: Always use this skill when writing or refactoring code` makes this a second system prompt, so cost pressure is highest here. The reduction comes almost entirely from cutting elaboration, **not** from deleting rules.
+
+Keep as one-liners (taste — nothing else tells the model our position):
+
+- [ ] Descriptive filenames over `utils.ts`/`helpers.ts`; rule of three before abstracting; declare close to usage; limit shadowing and reassignment; strict module boundaries; platform-specific code in separate files; lowercase `failed to X` error format
+
+Keep (counteracts a default):
+
+- [ ] **Correctness Over Convenience** (17–24) — happy-path bias is a real model tendency
+- [ ] Error-handling trichotomy (26–34) — recoverable / pass up / log-and-metric, never swallow
+
+Cut elaboration, keep the rule:
+
+- [ ] Flow control (111–146) — keep the one-line rule, cut the 30-line before/after TypeScript pair (~35 lines saved)
+- [ ] Descriptive filenames (64–89) — cut the four-bullet "why this matters" and the eight-item do/dont list; two examples each
+- [ ] Error format (41–51) — keep the two-line example pair, cut the surrounding explanation
+
+Cut outright:
+
+- [ ] Explicit over Implicit (9–15) — does not discriminate any actual decision
+- [ ] Red Flags (184–191) — restates four rules from above it
+- [ ] Functions should be small and focused (101–103) — consensus, restates a default
+
+Demote:
+
+- [ ] Property-Driven Design (158–182) → `references/property-driven-design.md`. Not a model default so it earns its place, but it is an occasional design technique, not an every-task rule
+
+- [ ] Run `nix flake check`

--- a/.beans/dotfiles-m7np--collapse-maintaining-project-context.md
+++ b/.beans/dotfiles-m7np--collapse-maintaining-project-context.md
@@ -1,0 +1,21 @@
+---
+# dotfiles-m7np
+title: Collapse maintaining-project-context
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-15T15:33:00Z
+updated_at: 2026-08-15T15:33:10Z
+parent: dotfiles-nj63
+blocked_by:
+    - dotfiles-nw9f
+---
+
+**File:** `home/lib/ai/skills/maintaining-project-context/SKILL.md` (182 → ~55 lines)
+
+The When-to-Update table (48–59), the step-by-step process (61–130), the Decision Tree (132–152), and the Quick Reference (154–169) are four renderings of one rule: *update context files when contracts change, not when implementation changes*. It also re-derives `writing-claude-md-files` content despite declaring it a required sub-skill.
+
+- [ ] Keep the AGENTS.md-vs-CLAUDE.md format detection and companion-pointer convention — non-obvious, repo-specific, unrecoverable from context
+- [ ] Collapse the four duplicate renderings into one paragraph plus the git-diff commands
+- [ ] Drop content that `writing-claude-md-files` owns (templates, freshness dates, the <100-line budget); rely on the declared sub-skill
+- [ ] Run `nix flake check`

--- a/.beans/dotfiles-nj63--rightsize-ai-skills-for-claude-5-context-engineeri.md
+++ b/.beans/dotfiles-nj63--rightsize-ai-skills-for-claude-5-context-engineeri.md
@@ -1,0 +1,31 @@
+---
+# dotfiles-nj63
+title: Rightsize AI skills for Claude 5 context engineering
+status: todo
+type: epic
+created_at: 2026-08-15T15:30:44Z
+updated_at: 2026-08-15T15:30:44Z
+---
+
+**Goal:** Rework `home/lib/ai/` skills and the claude-code skill-reinforcement hook against Anthropic's Claude 5 context-engineering guidance, cutting ~54% of directive lines without losing behaviour that is actually load-bearing.
+
+**Source:** https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models
+
+**Approved plan:** `~/.claude/plans/can-you-review-https-claude-com-blog-the-zesty-sonnet.md` — read this before starting any child task; it holds the per-file line references and rationale.
+
+## Cut criteria
+
+Every cut must be justified against one of these. "Claude already knows this" is explicitly **not** a valid justification.
+
+1. **Taste vs consensus** — taste stays; nothing else tells the model which side of a contested choice we're on.
+2. **Counteracts a default vs restates one** — rules resisting a known model tendency (happy-path bias, review agreeableness) are the most valuable thing a skill holds.
+3. **Cost to say** — cut elaboration, worked examples, and justification paragraphs. Keep the rule as a one-liner.
+
+Plus two independent grounds: **factually stale** (4.x-calibrated guidance now wrong) and **duplicated across sources**.
+
+**When unsure: demote to `references/`, don't delete.** Being wrong that way is cheap.
+
+## Constraints
+
+- Skills deploy to `~/.claude/skills/<name>/` on **every machine this flake is applied to** and run against arbitrary projects. A skill may reference only files shipped inside its own directory — repo-relative paths dangle silently elsewhere.
+- `nix flake check` is the gate (nixfmt + skill-name conflict assertions).

--- a/.beans/dotfiles-nw9f--rewrite-writing-claude-directives-for-claude-5.md
+++ b/.beans/dotfiles-nw9f--rewrite-writing-claude-directives-for-claude-5.md
@@ -1,0 +1,33 @@
+---
+# dotfiles-nw9f
+title: Rewrite writing-claude-directives for Claude 5
+status: todo
+type: task
+created_at: 2026-08-15T15:32:11Z
+updated_at: 2026-08-15T15:32:11Z
+parent: dotfiles-nj63
+---
+
+**File:** `home/lib/ai/skills/writing-claude-directives/SKILL.md` (272 lines → ~130)
+
+This is the meta-skill every other directive here was written under, so it goes first — otherwise the next rewrite reproduces the same shape. The cuts are **factually stale**, not merely redundant.
+
+Remove or restate:
+
+- [ ] Line 41 "Repetition enforces critical rules" — inverted; repetition across sources forces deliberation
+- [ ] Lines 74, 103, 249 — "Claude 4.x" calibration and overtriggering warnings
+- [ ] Line 39 "~150 instruction limit" — unsourced; real guidance is prune for conflict, not count
+- [ ] Line 151 "XML outperforms markdown for rule preservation" — a long-context workaround, not current guidance
+- [ ] Lines 224–232 — Opus 4.5 "think"-sensitivity note
+- [ ] Lines 90–99 — "Announce: I am using [skill]" structural enforcement (source of the announcement rituals elsewhere)
+- [ ] Lines 210–222 anti-overengineering block — cut as **duplication** with the harness system prompt, not because the rule is wrong
+
+Keep: discovery/`description` guidance (how skills get found), naming, progressive disclosure, token targets.
+
+Add:
+
+- [ ] The three cut criteria from the epic body
+- [ ] A rich-references section, subject to the portability constraint below
+- [ ] **Portability constraint** — skills deploy to `~/.claude/skills/<name>/` on every machine the flake touches and run against arbitrary projects, so a skill may reference only files shipped inside its own directory. Repo-relative paths dangle silently. Currently written down nowhere.
+- [ ] **Shared-policy extraction** — when 2+ skills need the same rule, extract it to its own skill and have each load it, rather than picking an owner and cross-referencing. Load order and co-presence are not guaranteed; skill loading is idempotent so a redundant load is free.
+- [ ] Run `nix flake check`

--- a/.beans/dotfiles-o58n--trim-brainstorming-and-writing-plans-rituals.md
+++ b/.beans/dotfiles-o58n--trim-brainstorming-and-writing-plans-rituals.md
@@ -1,0 +1,22 @@
+---
+# dotfiles-o58n
+title: Trim brainstorming and writing-plans rituals
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-15T15:33:00Z
+updated_at: 2026-08-15T15:33:10Z
+parent: dotfiles-nj63
+blocked_by:
+    - dotfiles-nw9f
+---
+
+**Files:** `home/lib/ai/skills/brainstorming/SKILL.md` (127), `home/lib/ai/skills/writing-plans/SKILL.md` (243)
+
+Both are mostly keeps — the HARD-GATE is a deliberate workflow guardrail (the article preserves strategic guardrails), and the plannotator/beans invocations are mechanism, which self-documenting-interface guidance says to keep.
+
+- [ ] `brainstorming` — cut Key Principles (120–127), which restates the Process section
+- [ ] `writing-plans` — cut the announcement ritual (line 14), an artifact of the 4.x structural-enforcement playbook
+- [ ] `writing-plans` — cut the Remember section (237–243), which restates Bite-Sized Granularity and No Placeholders
+- [ ] Leave `diff-scope` untouched — it is already the model of what the guidance asks for
+- [ ] Run `nix flake check`

--- a/.beans/dotfiles-p2is--replace-scripted-utterances-in-global-instructions.md
+++ b/.beans/dotfiles-p2is--replace-scripted-utterances-in-global-instructions.md
@@ -1,0 +1,23 @@
+---
+# dotfiles-p2is
+title: Replace scripted utterances in global-instructions
+status: todo
+type: task
+created_at: 2026-08-15T15:33:00Z
+updated_at: 2026-08-15T15:33:00Z
+parent: dotfiles-nj63
+---
+
+**File:** `home/lib/ai/global-instructions.md` (18 → ~8 lines)
+
+Deployed verbatim to `~/.claude/CLAUDE.md` and `~/.codex/AGENTS.md` — highest blast radius in the repo, and effects land outside it.
+
+The preferences are fine; "research before implementing" counteracts a real default. The problem is that all three are *scripted utterances* rather than rules:
+
+- [ ] `Start every feature with: "Let me research the codebase and create a plan before implementing."` — forced preamble even on one-line changes
+- [ ] `When uncertain: "Let me ultrathink about this architecture."` — a 4.x thinking-budget trigger phrase, not a behaviour
+- [ ] `When choosing: "I see approach A (simple) vs B (flexible). Which do you prefer?"` — scripted sentence for an intent already covered by default behaviour
+
+- [ ] Rewrite as three lines of intent: research before multi-step work; ask when two approaches genuinely diverge; prefer the simple solution when stuck
+- [ ] Resolve the overlap with `brainstorming`s HARD-GATE, which mandates a stricter version of the same flow — one of them should own it
+- [ ] Keep it assistant-agnostic (it ships to Codex too)

--- a/.beans/dotfiles-p4l3--trim-writing-claude-md-files.md
+++ b/.beans/dotfiles-p4l3--trim-writing-claude-md-files.md
@@ -1,0 +1,30 @@
+---
+# dotfiles-p4l3
+title: Trim writing-claude-md-files
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-15T15:33:00Z
+updated_at: 2026-08-15T15:33:10Z
+parent: dotfiles-nj63
+blocked_by:
+    - dotfiles-nw9f
+---
+
+**File:** `home/lib/ai/skills/writing-claude-md-files/SKILL.md` (301 → ~100 lines)
+
+Two full templates, a ~45-line synthetic auth example, then a Common Mistakes table and a Checklist restating the same rules a third and fourth time.
+
+Keep:
+
+- [ ] Top-level vs subdirectory distinction (the actual insight)
+- [ ] The section lists
+- [ ] Freshness-date requirement with `date +%Y-%m-%d` — a real hallucination guard; models will invent a date
+- [ ] The no-`@`-syntax rule — a real, non-obvious token cost
+
+**Do NOT point at repo files.** Replacing the synthetic example with a pointer to `home/lib/ai/CLAUDE.md` or `crates/CLAUDE.md` was explicitly rejected: `mkSkillFiles` deploys this skill to `~/.claude/skills/` on every machine the flake is applied to, and it runs in arbitrary projects. Those paths exist nowhere else and fail silently.
+
+- [ ] Cut the two templates and the Common Mistakes table (both restate the section lists)
+- [ ] Keep one compact synthetic example, self-contained in the file, roughly a third of the current auth walkthrough
+- [ ] Cut the Checklist — with templates gone, the section lists serve that purpose
+- [ ] Run `nix flake check`

--- a/.beans/dotfiles-vmit--extract-house-style-code-comments-skill.md
+++ b/.beans/dotfiles-vmit--extract-house-style-code-comments-skill.md
@@ -1,0 +1,26 @@
+---
+# dotfiles-vmit
+title: Extract house-style-code-comments skill
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-15T15:32:11Z
+updated_at: 2026-08-15T15:33:10Z
+parent: dotfiles-nj63
+blocked_by:
+    - dotfiles-nw9f
+---
+
+**New:** `home/lib/ai/skills/house-style-code-comments/SKILL.md` (~25 lines)
+
+The comment policy is currently stated three times at three strictness levels: `coding-effectively:148-156` ("omit entirely"), `comment-cleanup:34-61` ("no exceptions"), `critical-code-reviewer:86,92` ("an insult to the reader").
+
+Designating one owner and cross-referencing does not work — nothing guarantees `coding-effectively` is loaded when a review skill runs, and a PR review may never trigger the write-code skill at all. Extract to a shared skill instead, following the `diff-scope` idiom (`**REQUIRED**: Load the <skill> skill`).
+
+- [ ] Create the skill with `cc:user-invocable: false`. One strictness level, stated once: why-not-what, the removal categories, the four acceptable-comment cases
+- [ ] `coding-effectively` — drop 148–156, add the REQUIRED load line
+- [ ] `comment-cleanup` — drop 34–61, add the REQUIRED load line. Keep what is genuinely its own: the subagent-delegation protocol, the `git diff -U0` verification step, the finding format (121 → ~40 lines)
+- [ ] `critical-code-reviewer` — drop the comment bullets, add the REQUIRED load line
+- [ ] Run `nix flake check` (catches skill-name collisions via the `mkSkillFiles` assertions)
+
+Side benefit: the policy becomes independently editable instead of requiring three files and three phrasings to be reconciled.

--- a/home/programs/claude-code/hooks/skill-reinforcement.nix
+++ b/home/programs/claude-code/hooks/skill-reinforcement.nix
@@ -42,7 +42,7 @@ let
 in
 {
   config.dotfiles.programs.claude-code.hooks.skill-reinforcement = mkIf cfg.enable {
-    enable = true;
+    enable = mkDefault false;
     event = "UserPromptSubmit";
     hooks = [
       {


### PR DESCRIPTION
The `skill-reinforcement` hook injected a MANDATORY SKILL ACTIVATION SEQUENCE on every `UserPromptSubmit`, forcing a YES/NO verdict on all ~17 available skills before any work started. Claude 5 selects skills from their `description` frontmatter without prompting, so the enumeration bought nothing and cost a wall of "NO — not relevant" reasoning every turn, in every project.

Flips the default instead of deleting the hook. `mkDefault false` keeps the definition intact and one line from returning:

```nix
dotfiles.programs.claude-code.hooks.skill-reinforcement.enable = true;
```

`mergeHooks` already filters disabled hooks out of the generated `settings.json`, so no new plumbing was needed. Verified both directions by evaluating the module through `mkHomeManagerSystem`: with no host config the hook is absent from `UserPromptSubmit`; with the override it reappears. `mkDefault` is load-bearing rather than decorative — a plain `enable = false;` collides with a host's `enable = true;` at equal priority and fails evaluation.

This is the first task of a wider audit of `home/lib/ai/` against Anthropic's [Claude 5 context-engineering guidance](https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models), tracked under epic `dotfiles-nj63`. It lands deliberately on its own so its effect can be observed in isolation — if skills stop firing when they should, this is the single line to flip back.

The remaining 9 tasks of that epic land as separate PRs.

Follow-ups: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)