### PR TITLE
home/lib/ai: extract house-style-code-comments skill

### DIFF
--- a/.beans/dotfiles-vmit--extract-house-style-code-comments-skill.md
+++ b/.beans/dotfiles-vmit--extract-house-style-code-comments-skill.md
@@ -1,11 +1,11 @@
 ---
 # dotfiles-vmit
 title: Extract house-style-code-comments skill
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-08-15T15:32:11Z
-updated_at: 2026-08-15T15:33:10Z
+updated_at: 2026-08-15T16:24:19Z
 parent: dotfiles-nj63
 blocked_by:
     - dotfiles-nw9f
@@ -17,10 +17,20 @@ The comment policy is currently stated three times at three strictness levels: `
 
 Designating one owner and cross-referencing does not work — nothing guarantees `coding-effectively` is loaded when a review skill runs, and a PR review may never trigger the write-code skill at all. Extract to a shared skill instead, following the `diff-scope` idiom (`**REQUIRED**: Load the <skill> skill`).
 
-- [ ] Create the skill with `cc:user-invocable: false`. One strictness level, stated once: why-not-what, the removal categories, the four acceptable-comment cases
-- [ ] `coding-effectively` — drop 148–156, add the REQUIRED load line
-- [ ] `comment-cleanup` — drop 34–61, add the REQUIRED load line. Keep what is genuinely its own: the subagent-delegation protocol, the `git diff -U0` verification step, the finding format (121 → ~40 lines)
-- [ ] `critical-code-reviewer` — drop the comment bullets, add the REQUIRED load line
-- [ ] Run `nix flake check` (catches skill-name collisions via the `mkSkillFiles` assertions)
+- [x] Create the skill with `cc:user-invocable: false`. One strictness level, stated once: why-not-what, the removal categories, the four acceptable-comment cases
+- [x] `coding-effectively` — drop 148–156, add the REQUIRED load line
+- [x] `comment-cleanup` — drop 34–61, add the REQUIRED load line. Keep what is genuinely its own: the subagent-delegation protocol, the `git diff -U0` verification step, the finding format (121 → ~40 lines)
+- [x] `critical-code-reviewer` — drop the comment bullets, add the REQUIRED load line
+- [x] Run `nix flake check` (catches skill-name collisions via the `mkSkillFiles` assertions)
 
 Side benefit: the policy becomes independently editable instead of requiring three files and three phrasings to be reconciled.
+
+## Summary of Changes
+
+New skill `home/lib/ai/skills/house-style-code-comments/SKILL.md` (44 lines) is now the single statement of the comment policy. All three consumers load it via the `**REQUIRED**: Load the '<skill>' skill` idiom; `comment-cleanup` drops 121 → 95 lines.
+
+**A policy conflict surfaced and was resolved deliberately.** The three copies had drifted: `coding-effectively` endorsed explaining "why a non-obvious approach was chosen over the obvious one", while `comment-cleanup` unconditionally removed comments that "argue with an approach that is not in the code". Nothing forced a resolution before, because no agent ever loaded both. The first draft of the merge silently picked the ban. Now stated explicitly: the line is whether a concrete failure mode is named — "the obvious `map` here deadlocks under concurrent writes" stays, "rather than a map" goes.
+
+**From subagent review:** disambiguated `comment-cleanup:59` where the recursion guard said "do not have it load this skill" — with `house-style-code-comments` named 20 words earlier, the nearest-antecedent reading inverted the instruction and would have left the subagent judging against no criteria at all; narrowed an overbroad "the reasoning behind a change belongs in the commit message" that had grown to cover the entire keep-list four lines below it; fixed a stale "criteria above" reference; removed a surviving framing restatement; and mapped the policy's categories onto the reviewer's severity tiers at the `critical-code-reviewer` call site, since that consumer reports rather than edits.
+
+`nix flake check` passes — no skill-name collision. User review returned no changes.

--- a/home/lib/ai/skills/coding-effectively/SKILL.md
+++ b/home/lib/ai/skills/coding-effectively/SKILL.md
@@ -147,13 +147,7 @@ return value;
 
 ### Code comments
 
-Every comment must earn its place. The only comments worth keeping explain **why** the code does something, never **what** — code is the single source of truth for "what", so a comment that restates it is redundant at best and a future lie at worst.
-
-- Explain *why*: why a non-obvious approach was chosen over the obvious one, why a workaround exists (link the issue when possible), why a particular value or threshold was picked, or domain/business context the code cannot express.
-- Omit "what" comments entirely. If code is too opaque to follow without one, fix the code (better names, extracted functions, clearer structure) rather than paper over it with a comment.
-- Never leave comments that are artifacts of the change itself — the plan, the discussion, or how the code got here (`// as discussed`, `// new approach`, `// per the plan`). They are temporally coupled to a moment that the reader wasn't present for and can't recover.
-- Never describe what the code **used to do** (`// previously returned null`, `// no longer uses the cache`). Comments describe what *is*; historical narration is actively harmful because it contradicts the code the instant it's read.
-- Avoid comments that are likely to churn when the code structure changes.
+**REQUIRED**: Load the 'house-style-code-comments' skill for the comment policy.
 
 ## Property-Driven Design
 

--- a/home/lib/ai/skills/comment-cleanup/SKILL.md
+++ b/home/lib/ai/skills/comment-cleanup/SKILL.md
@@ -5,7 +5,7 @@ description: Analyze and clean up code comments for accuracy, completeness, and 
 
 # Comment Cleanup
 
-Analyze and fix code comments within changed code. Supports the current diff, the most recent commit, or all commits on the current branch. Every comment must earn its place by providing clear, lasting value. Inaccurate or outdated comments create technical debt that compounds over time.
+Analyze and fix code comments within changed code. Supports the current diff, the most recent commit, or all commits on the current branch. Inaccurate or outdated comments create technical debt that compounds over time.
 
 ## Scope
 
@@ -31,33 +31,7 @@ Cross-reference every claim against the actual code:
 
 ### 2. Value Assessment
 
-A comment must justify its existence. The only acceptable comments explain **why** the code does something, never **what** it does. Code is the single source of truth for "what" -- any comment that restates it is redundant at best and a future lie at worst.
-
-Default to removal. Keep a comment only when you can name the specific wrong action a reader would take without it -- a change they would make that silently breaks something. "It adds useful context" is not an answer.
-
-**Remove unconditionally** any comment that:
-
-- Restates or paraphrases what the code does (e.g. `// increment counter`, `// return the result`, `// loop through items`)
-- Names the operation being performed (e.g. `// fetch user data` above a `fetchUserData()` call)
-- Describes control flow that is already expressed by the code structure (e.g. `// check if null`, `// handle error case`)
-- Translates code into English without adding context the code itself does not convey
-- Exists only because "the function/block should have a comment"
-- Argues with an approach that is not in the code (`// rather than X`, `// the obvious way would be Y, but`). These pass the why-not-what test yet answer a question the reader never asked, and they age badly as the alternative loses relevance. Bug-fix archaeology belongs in the commit message.
-
-There are **no exceptions** for "what" comments. If the code is too opaque to understand without a "what" comment, the code itself should be refactored (better names, extracted functions, clearer structure) -- not papered over with a comment.
-
-**Also flag** comments that:
-
-- Will become stale with likely code changes
-- Reference temporary states or transitional implementations
-- Contain TODOs or FIXMEs that have already been addressed
-
-**Acceptable comments** explain:
-
-- **Why** a workaround exists, linking the issue or bug when possible
-- **Why** a particular value, threshold, or constraint was picked
-- A load-bearing subtlety whose removal would silently break something
-- Domain or business context that cannot be expressed in code
+**REQUIRED**: Load the 'house-style-code-comments' skill. It defines which comments earn their place, which are removed unconditionally, and which are worth keeping.
 
 ### 3. Completeness
 
@@ -78,11 +52,11 @@ Flag comments that could mislead future maintainers:
 
 ## Delegating the judgment pass
 
-Dispatch a subagent to decide what to cut, then verify its work. The criteria above are what you hand it rather than a pass you run first.
+Dispatch a subagent to decide what to cut, then verify its work. The criteria in this section are what you hand it rather than a pass you run first.
 
 An author cannot review their own comments: having written the code, every comment feels load-bearing because the bug behind it is still fresh. A reviewer with no stake in the change carries no such attachment.
 
-Give the subagent the in-scope files, the criteria above (inline -- it should not load this skill and dispatch again), and the framing that it is a principal engineer whose default answer to "should this comment exist?" is no. Have it apply its removals and rewrites directly, and return them in the finding format below with line numbers as they stood before its edits.
+Give the subagent the in-scope files, the framing that it is a principal engineer whose default answer to "should this comment exist?" is no, and the criteria: tell it to load 'house-style-code-comments' for the value judgment, and pass the accuracy, completeness, and clarity criteria above inline. Do not have it load `comment-cleanup` -- it would dispatch a subagent of its own. Have it apply its removals and rewrites directly, and return them in the finding format below with line numbers as they stood before its edits.
 
 Verify before reporting:
 

--- a/home/lib/ai/skills/critical-code-reviewer/SKILL.md
+++ b/home/lib/ai/skills/critical-code-reviewer/SKILL.md
@@ -83,13 +83,13 @@ Outdated descriptions and misleading comments should be noted in your review.
 
 Identify and reject:
 
-- **Obvious comments**: `// increment counter` above `counter++` or `# loop through items` above a for loop—an insult to the reader
 - **Lazy naming**: `data`, `temp`, `result`, `handle`, `process`, `df`, `df2`, `x`, `val`—words that communicate nothing
 - **Copy-paste artifacts**: Similar blocks that scream "I didn't think about abstraction"
 - **Cargo cult code**: Patterns used without understanding why (e.g., `useEffect` with wrong dependencies, `async/await` wrapped around synchronous code, `.apply()` in pandas where vectorization works)
 - **Premature abstraction AND missing abstraction**: Both are failures of judgment
 - **Dead code**: Commented-out blocks, unreachable branches, unused imports/variables
-- **Overuse of comments**: Well-named functions and variables should explain intent without comments
+
+**REQUIRED**: Load the 'house-style-code-comments' skill for judging comments in the diff. Its "always remove" categories are Required Changes; its "also flag" categories are Suggestions.
 
 ### 4. Structural Contempt
 

--- a/home/lib/ai/skills/house-style-code-comments/SKILL.md
+++ b/home/lib/ai/skills/house-style-code-comments/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: house-style-code-comments
+description: Use when writing, reviewing, or cleaning up code comments. Defines which comments earn their place - why-not-what, the categories that always get removed, and the few kinds worth keeping.
+cc:user-invocable: false
+---
+
+# House Style: Code Comments
+
+Every comment must earn its place. Code is the single source of truth for *what* it does, so a comment restating it is redundant on the day it lands and a lie the first time the code changes without it.
+
+The only comments worth keeping explain **why**.
+
+## Default to removal
+
+Keep a comment only when you can name the specific wrong action a reader would take without it — a change they would make that silently breaks something. "It adds useful context" is not an answer.
+
+## Always remove
+
+- Restates or paraphrases what the code does — `// increment counter`, `// return the result`, `// loop through items`
+- Names the operation being performed — `// fetch user data` above a `fetchUserData()` call
+- Describes control flow the code structure already expresses — `// check if null`, `// handle error case`
+- Translates code into English without adding anything the code does not convey
+- Exists because the function or block "should have a comment"
+- Argues with an approach that is not in the code — `// rather than X`, `// the obvious way would be Y, but`. These pass the why-not-what test but answer a question the reader never asked, and they age badly as the alternative loses relevance. The line is whether a concrete failure mode is named: "the obvious `map` here deadlocks under concurrent writes" is worth keeping; "rather than a map" on its own is not.
+- Narrates the change that introduced it — `// as discussed`, `// new approach`, `// per the plan`. Temporally coupled to a moment the reader was not present for and cannot recover.
+- Describes what the code **used to do** — `// previously returned null`, `// no longer uses the cache`. Comments describe what *is*; historical narration contradicts the code the instant it is read.
+
+There are no exceptions for "what" comments. If code is too opaque to follow without one, fix the code — better names, extracted functions, clearer structure — rather than papering over it.
+
+Bug-fix archaeology — the sequence of attempts behind the current code — belongs in the commit message, which is where someone will go looking for it.
+
+## Worth keeping
+
+- **Why** a non-obvious approach was necessary, when the obvious one has a concrete failure mode worth naming
+- **Why** a workaround exists, linking the issue when possible
+- **Why** a particular value, threshold, or constraint was chosen
+- A load-bearing subtlety whose removal would silently break something
+- Domain or business context the code cannot express
+
+## Also flag
+
+- Comments likely to churn when the code structure changes
+- References to temporary states or transitional implementations
+- TODOs and FIXMEs that have already been addressed


### PR DESCRIPTION
The code-comment policy was stated three times, at three different strictness levels — `coding-effectively` ("omit entirely"), `comment-cleanup` ("no exceptions"), `critical-code-reviewer` ("an insult to the reader").

Nominating one as owner and having the others cross-reference it does not work here: load order and co-presence aren't guaranteed, and a review of an existing PR may never trigger the write-code skill at all, which would leave the reviewer with no comment policy. Extracted to a shared skill instead, loaded explicitly by all three via the `**REQUIRED**: Load the '<skill>' skill` idiom that `diff-scope` already uses.

**Merging the copies exposed a conflict they had been hiding from each other.** `coding-effectively` endorsed explaining "why a non-obvious approach was chosen over the obvious one"; `comment-cleanup` unconditionally removed comments that "argue with an approach that is not in the code". Both shipped for months without contradiction, because nothing ever loaded both at once.

The first draft of this merge silently resolved it in favour of the ban. It is now an explicit rule — the line is whether a concrete failure mode is named:

> "the obvious `map` here deadlocks under concurrent writes" — keep
> "rather than a map" — remove

Net effect: `comment-cleanup` 121 → 95 lines, the policy stated once in 44, and it becomes independently editable instead of requiring three files and three phrasings to be reconciled.

Unblocks `dotfiles-emaa` (coding-effectively) and `dotfiles-0i9f` (critical-code-reviewer) under epic `dotfiles-nj63`. `nix flake check` passes — no skill-name collision.

Follow-ups: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)