### PR TITLE
home/lib/ai: trim coding-effectively to rules without elaboration

### DIFF
--- a/.beans/dotfiles-emaa--trim-coding-effectively-to-rules-without-elaborati.md
+++ b/.beans/dotfiles-emaa--trim-coding-effectively-to-rules-without-elaborati.md
@@ -1,11 +1,11 @@
 ---
 # dotfiles-emaa
 title: Trim coding-effectively to rules without elaboration
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-08-15T15:32:59Z
-updated_at: 2026-08-15T15:33:10Z
+updated_at: 2026-08-15T16:36:58Z
 parent: dotfiles-nj63
 blocked_by:
     - dotfiles-vmit
@@ -17,27 +17,39 @@ blocked_by:
 
 Keep as one-liners (taste — nothing else tells the model our position):
 
-- [ ] Descriptive filenames over `utils.ts`/`helpers.ts`; rule of three before abstracting; declare close to usage; limit shadowing and reassignment; strict module boundaries; platform-specific code in separate files; lowercase `failed to X` error format
+- [x] Descriptive filenames over `utils.ts`/`helpers.ts`; rule of three before abstracting; declare close to usage; limit shadowing and reassignment; strict module boundaries; platform-specific code in separate files; lowercase `failed to X` error format
 
 Keep (counteracts a default):
 
-- [ ] **Correctness Over Convenience** (17–24) — happy-path bias is a real model tendency
-- [ ] Error-handling trichotomy (26–34) — recoverable / pass up / log-and-metric, never swallow
+- [x] **Correctness Over Convenience** (17–24) — happy-path bias is a real model tendency
+- [x] Error-handling trichotomy (26–34) — recoverable / pass up / log-and-metric, never swallow
 
 Cut elaboration, keep the rule:
 
-- [ ] Flow control (111–146) — keep the one-line rule, cut the 30-line before/after TypeScript pair (~35 lines saved)
-- [ ] Descriptive filenames (64–89) — cut the four-bullet "why this matters" and the eight-item do/dont list; two examples each
-- [ ] Error format (41–51) — keep the two-line example pair, cut the surrounding explanation
+- [x] Flow control (111–146) — keep the one-line rule, cut the 30-line before/after TypeScript pair (~35 lines saved)
+- [x] Descriptive filenames (64–89) — cut the four-bullet "why this matters" and the eight-item do/dont list; two examples each
+- [x] Error format (41–51) — keep the two-line example pair, cut the surrounding explanation
 
 Cut outright:
 
-- [ ] Explicit over Implicit (9–15) — does not discriminate any actual decision
-- [ ] Red Flags (184–191) — restates four rules from above it
-- [ ] Functions should be small and focused (101–103) — consensus, restates a default
+- [x] Explicit over Implicit (9–15) — does not discriminate any actual decision
+- [x] Red Flags (184–191) — restates four rules from above it
+- [x] Functions should be small and focused (101–103) — consensus, restates a default
 
 Demote:
 
-- [ ] Property-Driven Design (158–182) → `references/property-driven-design.md`. Not a model default so it earns its place, but it is an occasional design technique, not an every-task rule
+- [x] Property-Driven Design (158–182) → `references/property-driven-design.md`. Not a model default so it earns its place, but it is an occasional design technique, not an every-task rule
 
-- [ ] Run `nix flake check`
+- [x] Run `nix flake check`
+
+## Summary of Changes
+
+`coding-effectively/SKILL.md`: 185 → 56 lines, plus a new 23-line `references/property-driven-design.md`.
+
+Every rule on the keep list survives. The reduction is elaboration: the 30-line before/after TypeScript flow-control pair, the four-bullet "why this matters" under filenames, and the do/don't lists. Flow control actually gained — the original demonstrated early-return only inside the code sample, so "return early instead of nesting" is now stated outright.
+
+**Three rules were lost and restored.** Subagent review caught that the authorized "Red Flags" cut took two unique rules with it: the prohibition on bypassing the type system (`as any`, unchecked casts) appeared nowhere else in the entire skill library, and "no generic error messages" was gone — `throw new Error("something went wrong")` passed every remaining rule in the file. Separately, the platform-branching mechanism (conditional compilation or a runtime check) was dropped while the rule about *where* platform code lives was kept, leaving the reader told to split `unix.ts`/`windows.ts` with no guidance on dispatch. All three restored by folding into existing lines, at no net line cost.
+
+Also from review: restored the open-ended framing of the edge-case list (a compression had turned three examples into a closed set, on one of the two paragraphs specifically justified as counteracting happy-path bias); strengthened the reference pointer from "see X" to "Before implementing a feature, read X", since the weaker verb sat 20 lines from a `**REQUIRED**: Load` and read as optional by comparison; and cut a property-based-testing line I had added to the reference, which was scope creep in a trim.
+
+`nix flake check` passes. User review returned no changes.

--- a/home/lib/ai/skills/coding-effectively/SKILL.md
+++ b/home/lib/ai/skills/coding-effectively/SKILL.md
@@ -6,180 +6,51 @@ cc:user-invocable: false
 
 # Coding Effectively
 
-## Core Engineering Principles
+## Correctness over convenience
 
-### Explicit over Implicit
+Model the full error space, not the path you had in mind. Handle every edge case — race conditions, timing issues, partial failures. Encode constraints in the type system, and prefer compile-time guarantees to runtime checks. Never bypass the type system to silence a compiler error (`as any`, unchecked casts). When uncertain, explore and iterate rather than assume.
 
-- Clear function names over clever abstractions
-- Obvious data flow over hidden magic
-- Direct dependencies over unnecessary indirection
+## Error handling
 
-### Correctness Over Convenience
+Never swallow an error. Every error is one of three things:
 
-Model the full error space. No shortcuts.
+- **Recoverable locally** — handle it
+- **Unrecoverable locally** — pass it up the stack
+- **Non-critical** — log it, increment a metric, or both
 
-- Handle all edge cases: race conditions, timing issues, partial failures
-- Use the type system to encode correctness constraints
-- Prefer compile-time guarantees over runtime checks where possible
-- When uncertain, explore and iterate rather than assume
+Two tiers: user-facing errors get semantic exit codes, rich diagnostics, and actionable messages. Internal errors are programming errors, and may panic or use internal types. Never emit a generic message where the specific cause is known.
 
-### Error Handling Philosophy
-
-Errors should never be swallowed. When handling errors there are multiple options:
-
-- recoverable locally - error handled
-- unrecoverable locally - pass up the stack
-- non-critical error - log the error or increment metrics, or both
-
-But you should never swallow errors unhandled.
-
-**Two-tier model:**
-
-1. **User-facing errors**: Semantic exit codes, rich diagnostics, actionable messages
-2. **Internal errors**: Programming errors that may panic or use internal types
-
-**Error message format:** Lowercase sentence fragments for "failed to {message}".
+**Message format** — lowercase sentence fragments, so that `"operation failed: " + error.message` composes:
 
 ```
 Good: failed to connect to database: connection refused
 Bad:  Failed to Connect to Database: Connection Refused
-
-Good: invalid configuration: missing required field 'apiKey'
-Bad:  Invalid Configuration: Missing Required Field 'apiKey'
 ```
 
-Lowercase fragments compose naturally: `"operation failed: " + error.message` reads correctly.
+## Design
 
-### Pragmatic Incrementalism
+- Don't abstract until you have seen the pattern three times. Three similar lines beat a premature abstraction.
+- Prefer specific, composable logic over abstract frameworks.
+- Evolve the design incrementally rather than perfecting it upfront, and don't build for hypothetical future requirements.
+- Document the trade-off when making a non-obvious choice.
 
-- Prefer specific, composable logic over abstract frameworks
-- Evolve design incrementally rather than perfect upfront architecture
-- Don't build for hypothetical future requirements
-- Document design decisions and trade-offs when making non-obvious choices
+Before implementing a feature, read `references/property-driven-design.md`. Property questions surface design gaps — deleted entities, case sensitivity, tie-breaking — during design rather than during debugging.
 
-**The rule of three applies to abstraction:** Don't abstract until you've seen the pattern three times. Three similar lines of code is better than a premature abstraction.
+## File organization
 
-## File Organization
+- Name files for what they contain, never a generic category: `string-formatting.ts`, `date-arithmetic.ts`, `user-validation.ts`, not `utils.ts` or `helpers.ts`. When tempted to create one of those, ask what the functions have in common and name the file after that.
+- Keep module boundaries strict, with restricted visibility.
+- Platform-specific code goes in its own file: `unix.ts`, `windows.ts`, `posix.ts`, selected by conditional compilation or a runtime check.
+- Test helpers belong in dedicated modules, not mixed into production code.
+- Prefer many small files to a few large ones.
 
-### Descriptive File Names Over Catch-All Files
+## Style
 
-Name files by what they contain, not by generic categories.
+- Keep the happy path left-aligned. Return early instead of nesting.
+- Declare identifiers in the files that need them; export or make public only when something else needs them.
+- Declare variables close to their usage.
+- Limit assignment scope — reassignment and shadowing cause subtle bugs.
 
-**Don't create:**
-
-- `utils.ts` - Becomes a dumping ground for unrelated functions
-- `helpers.ts` - Same problem
-- `common.ts` - What isn't common?
-- `misc.ts` - Actively unhelpful
-
-**Do create:**
-
-- `string-formatting.ts` - String manipulation utilities
-- `date-arithmetic.ts` - Date calculations
-- `api-error-handling.ts` - API error utilities
-- `user-validation.ts` - User input validation
-
-**Why this matters:**
-
-- Discoverability: Developers find code by scanning file names
-- Cohesion: Related code stays together
-- Prevents bloat: Hard to add unrelated code to `string-formatting.ts`
-- Import clarity: `import { formatDate } from './date-arithmetic'` is self-documenting
-
-**When you're tempted to create utils.ts:** Stop. Ask what the functions have in common. Name the file after that commonality.
-
-### Module Organization
-
-- Keep module boundaries strict with restricted visibility
-- Platform-specific code in separate files: `unix.ts`, `windows.ts`, `posix.ts`
-- Use conditional compilation or runtime checks for platform branching
-- Test helpers in dedicated modules/files, not mixed with production code
-- Prefer many small files over few large ones
-
-## Code style
-
-### Functions should be small and focused
-
-Small and focused functions promote cohesion and testability. If you find a function does more than one thing conceptually, or you are tempted to put 'And' in the name of the function: it does too much.
-
-### Declare close to usage
-
-- Declare identifiers in files that need them. Only export or make public if necessary.
-- Within a function, declare variables as close to their usage as possible.
-- Limit assignment scope: reassigning and shadowing variables can lead to subtle bugs.
-
-### Flow control
-
-Always keep the happy path left-aligned, avoid deeply nested if-blocks. This harms readability and makes it harder to modify.
-
-**Don't**:
-
-```ts
-const possibleValues = getPossibleValues();
-const value = getSelected();
-if (value !== null) {
-  if (possibleValues.contains(value)) {
-    return value;
-  }
-
-  return null;
-}
-
-return null;
-```
-
-**Do**:
-
-```ts
-const possibleValues = getPossibleValues();
-const value = getSelected();
-
-if (value === null) {
-  return null;
-}
-
-if (!possibleValues.contains(value)) {
-  return null;
-}
-
-return value;
-```
-
-### Code comments
+## Code comments
 
 **REQUIRED**: Load the 'house-style-code-comments' skill for the comment policy.
-
-## Property-Driven Design
-
-When designing features, think about properties upfront. This surfaces design gaps early.
-
-**Discovery questions:**
-
-| Question                               | Property Type  | Example                        |
-| -------------------------------------- | -------------- | ------------------------------ |
-| Does it have an inverse operation?     | Roundtrip      | `decode(encode(x)) == x`       |
-| Is applying it twice the same as once? | Idempotence    | `f(f(x)) == f(x)`              |
-| What quantities are preserved?         | Invariants     | Length, sum, count unchanged   |
-| Is order of arguments irrelevant?      | Commutativity  | `f(a, b) == f(b, a)`           |
-| Can operations be regrouped?           | Associativity  | `f(f(a,b), c) == f(a, f(b,c))` |
-| Is there a neutral element?            | Identity       | `f(x, 0) == x`                 |
-| Is there a reference implementation?   | Oracle         | `new(x) == old(x)`             |
-| Can output be easily verified?         | Easy to verify | `is_sorted(sort(x))`           |
-
-**Common design questions these reveal:**
-
-- "What about deleted/deactivated entities?"
-- "Case-sensitive or not?"
-- "Stable sort or not? Tie-breaking rules?"
-- "Which algorithm? Configurable?"
-
-Surface these during design, not during debugging.
-
-## Red Flags
-
-**Stop and refactor when you see:**
-
-- That you are adding to `utils` or `helpers` file
-- Error handling that swallows errors or uses generic messages
-- Abstractions created for single use cases
-- Type assertions (`as any`) to bypass the type system

--- a/home/lib/ai/skills/coding-effectively/references/property-driven-design.md
+++ b/home/lib/ai/skills/coding-effectively/references/property-driven-design.md
@@ -1,0 +1,23 @@
+# Property-Driven Design
+
+Ask what properties a feature should hold before implementing it. The questions surface design gaps early, while they are still cheap.
+
+| Question | Property | Example |
+| --- | --- | --- |
+| Does it have an inverse operation? | Roundtrip | `decode(encode(x)) == x` |
+| Is applying it twice the same as once? | Idempotence | `f(f(x)) == f(x)` |
+| What quantities are preserved? | Invariant | length, sum, count unchanged |
+| Is argument order irrelevant? | Commutativity | `f(a, b) == f(b, a)` |
+| Can operations be regrouped? | Associativity | `f(f(a,b), c) == f(a, f(b,c))` |
+| Is there a neutral element? | Identity | `f(x, 0) == x` |
+| Is there a reference implementation? | Oracle | `new(x) == old(x)` |
+| Can output be checked without recomputing it? | Easy to verify | `is_sorted(sort(x))` |
+
+These reliably expose the questions that otherwise surface as bugs:
+
+- What about deleted or deactivated entities?
+- Case-sensitive or not?
+- Stable sort? What are the tie-breaking rules?
+- Which algorithm, and is it configurable?
+
+Surface these during design, not during debugging.


### PR DESCRIPTION
`coding-effectively` declares `description: Always use this skill when writing or refactoring code`, which makes it a second system prompt and its always-loaded cost the highest in the library.

**185 → 56 lines**, plus a 23-line on-demand `references/property-driven-design.md`.

The reduction is elaboration, not rules:

- a 30-line before/after TypeScript pair illustrating "keep the happy path left-aligned"
- a four-bullet "why this matters" justifying descriptive filenames
- do/don't lists restating their own headings

Every rule on the keep list survives as a one-liner. Flow control actually gained: the original demonstrated early-return only inside the code sample, so "return early instead of nesting" is now stated outright rather than left implicit.

Cut outright: "Explicit over Implicit" (three bullets that didn't discriminate any actual decision), "Red Flags" (restated four rules from above it), and "functions should be small and focused".

**Three rules were lost in the first draft and restored after review.** The authorized "Red Flags" cut took two unique rules with it — the prohibition on bypassing the type system (`as any`, unchecked casts), which appears nowhere else in the entire skill library, and "no generic error messages", without which `throw new Error("something went wrong")` passed every remaining rule in the file. The platform-branching mechanism was also dropped while the rule about *where* platform code lives was kept, leaving the reader told to split `unix.ts`/`windows.ts` with no guidance on dispatch. All three restored by folding into existing lines, at no net line cost.

That is the failure mode this whole epic is exposed to — trimming something that turns out to be load-bearing — so it is worth noting the review caught it rather than the tests, because no test exists for a directive.

Part of epic `dotfiles-nj63`. `nix flake check` passes.

Follow-ups: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)