### PR TITLE
home/lib/ai: restate critical-code-reviewer plainly

### DIFF
--- a/.beans/dotfiles-0i9f--restate-critical-code-reviewer-plainly.md
+++ b/.beans/dotfiles-0i9f--restate-critical-code-reviewer-plainly.md
@@ -1,11 +1,11 @@
 ---
 # dotfiles-0i9f
 title: Restate critical-code-reviewer plainly
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-08-15T15:32:59Z
-updated_at: 2026-08-15T15:33:10Z
+updated_at: 2026-08-15T17:21:29Z
 parent: dotfiles-nj63
 blocked_by:
     - dotfiles-vmit
@@ -17,14 +17,26 @@ The adversarial stance **stays** — the model default in review is agreeablenes
 
 Restate in place, do not delete:
 
-- [ ] "Guilty until proven exceptional" → Assume nothing works until the code demonstrates it does
-- [ ] "Every unhandled Promise will reject at 3 AM" → Unhandled rejections surface in production, not in review
-- [ ] "Structural contempt" → Code organisation reveals thinking; flag it
-- [ ] "Assume the worst intentions and the sloppiest habits" → Read for what the code does, not what it appears to intend
-- [ ] "An insult to the reader" → moves to `house-style-code-comments`
+- [x] "Guilty until proven exceptional" → Assume nothing works until the code demonstrates it does
+- [x] "Every unhandled Promise will reject at 3 AM" → Unhandled rejections surface in production, not in review
+- [x] "Structural contempt" → Code organisation reveals thinking; flag it
+- [x] "Assume the worst intentions and the sloppiest habits" → Read for what the code does, not what it appears to intend
+- [x] "An insult to the reader" → moves to `house-style-code-comments`
 
 Keep: the diff-scope handoff, the cross-repo PRECONDITION guard (a real boundary, correctly forceful), the `pr-checkout.sh` steps, the four severity tiers, the response format, the subagent-mode note (179).
 
-- [ ] Compress (do not delete) the Slop Detector and Adversarial Lens lists (82–116) by roughly half — they work as recall aids
-- [ ] Keep **both** anti-manufacturing correctives (163, 203) through the rewrite. Drop one only after re-reading real review output and confirming honesty holds without it
-- [ ] Run `nix flake check`
+- [x] Compress (do not delete) the Slop Detector and Adversarial Lens lists (82–116) by roughly half — they work as recall aids
+- [x] Keep **both** anti-manufacturing correctives (163, 203) through the rewrite. Drop one only after re-reading real review output and confirming honesty holds without it
+- [x] Run `nix flake check`
+
+## Summary of Changes
+
+`critical-code-reviewer/SKILL.md`: 203 → 190 lines. The adversarial stance is preserved and restated plainly rather than performed.
+
+The line count is well short of the ~110 estimate, and that estimate was simply wrong for this file. The theatre compressed as expected, but most of what remains is mechanism the bean says to keep — the PR-reference steps, the cross-repo guard, `pr-checkout.sh`, the response format. Two review rounds then restored content, which is the right trade.
+
+**Restated, not cut:** "guilty until proven exceptional" → assume nothing works until the code shows it does; "every unhandled Promise will reject at 3 AM" → these surface in production, not in review; "structural contempt" → code organisation reveals thinking; "assume the worst intentions" → read for what the code does, not what it appears to intend. The new opening names the failure mode it is resisting (agreeableness — fewer issues surfaced, severity softened), which is a stronger instruction than the register it replaced because it says what to resist rather than performing a mood.
+
+**Restored after subagent review** caught them missing from the first pass: the exhaustiveness mandate ("find every flaw, not just the ones that are easy to see") had no successor anywhere — the mapping covered stance but never coverage, which matters most in a skill whose purpose is countering under-reporting; the 500-line component threshold, the only concrete checkable number in its section; and unused variables in the dead-code item. Also merged "Operating Constraints" and "When Uncertain", which were two renderings of the same rule.
+
+**Both deferred questions resolved in this PR at user request** (`dotfiles-hjsw`, `dotfiles-wpey`): dropped the redundant anti-manufacturing corrective, keeping the one attached to the approval decision; and promoted "Verify" from a dangling instruction to a real severity tier with a slot in the response template.

--- a/.beans/dotfiles-hjsw--decide-whether-critical-code-reviewer-still-needs.md
+++ b/.beans/dotfiles-hjsw--decide-whether-critical-code-reviewer-still-needs.md
@@ -1,0 +1,26 @@
+---
+# dotfiles-hjsw
+title: Decide whether critical-code-reviewer still needs two anti-manufacturing correctives
+status: completed
+type: task
+priority: low
+created_at: 2026-08-15T16:48:12Z
+updated_at: 2026-08-15T17:21:11Z
+parent: dotfiles-nj63
+---
+
+Both "don't manufacture problems" correctives were deliberately retained through the plain-restatement rewrite (`critical-code-reviewer/SKILL.md`, the Before Finalizing self-check and the closing note on approval).
+
+The rewrite predicted one would become unnecessary once the framing was calibrated rather than maximal. Subagent review agreed and recommended dropping the Before Finalizing bullet, keeping the closing one: it sits at the approval decision, which is when the pressure to invent a finding actually bites, whereas the other is the fourth item in a self-check list whose other three push toward more rigor.
+
+Deliberately deferred, because the evidence does not exist yet: every review run so far used the pre-rewrite framing. Decide after the new version has done real reviews.
+
+- [ ] Run several real reviews under the new framing
+- [ ] Confirm findings stay honest and no manufactured issues appear
+- [ ] If so, drop the Before Finalizing bullet and reword "If you can't answer the first three" to "these three"
+
+## Summary of Changes
+
+Done immediately rather than deferred — user review said "just do this".
+
+Dropped the `Before Finalizing` bullet ("Have I flagged actual problems, or am I manufacturing issues?") and reworded the follow-on line from "the first three" to "these three". The corrective attached to the approval decision survives, which is the one that fires when the pressure to invent a finding actually bites.

--- a/.beans/dotfiles-wpey--reconcile-the-verify-marker-with-critical-code-rev.md
+++ b/.beans/dotfiles-wpey--reconcile-the-verify-marker-with-critical-code-rev.md
@@ -1,0 +1,23 @@
+---
+# dotfiles-wpey
+title: Reconcile the "Verify" marker with critical-code-reviewer severity tiers
+status: completed
+type: bug
+priority: low
+created_at: 2026-08-15T16:48:12Z
+updated_at: 2026-08-15T17:21:11Z
+parent: dotfiles-nj63
+---
+
+Pre-existing, not introduced by the restatement rewrite.
+
+`critical-code-reviewer/SKILL.md` tells the reviewer to mark uncertain findings as "Verify" rather than "Blocking" (twice, in "When You Can't Be Sure"), but "Verify" is not one of the four severity tiers (Blocking / Required Changes / Strong Suggestions / Noted) and has no slot in the response-format template. A reviewer following the instruction has nowhere to put the result.
+
+- [ ] Either add Verify as a tier with a template section, or fold it into an existing tier
+- [ ] Update both call sites and the response format consistently
+
+## Summary of Changes
+
+Done immediately rather than deferred — user review said to add it to the template.
+
+"Verify" is now a real tier rather than a dangling instruction. It appears in all three places that needed it: the instruction in "When You Can't Be Sure" (line 122), the severity tiers as tier 5 (line 136), and its own section in the response-format template (line 180).

--- a/home/lib/ai/skills/critical-code-reviewer/SKILL.md
+++ b/home/lib/ai/skills/critical-code-reviewer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: critical-code-reviewer
 description: >
-  Conduct rigorous, adversarial code reviews with zero tolerance for mediocrity.
+  Conduct rigorous, adversarial code reviews.
   Use when users ask to "critically review" my code or a PR, "critique my code",
   "find issues in my code", or "what's wrong with this code". Identifies
   security holes, lazy patterns, edge case failures, and bad practices. Scrutinizes error
@@ -11,9 +11,9 @@ description: >
 cc:allowed-tools: Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh repo view:*), Bash(git diff:*), Bash(git merge-base:*), Bash(git rev-parse:*)
 ---
 
-You are a senior engineer conducting PR reviews with zero tolerance for mediocrity and laziness. Your mission is to ruthlessly identify every flaw, inefficiency, and bad practice in the submitted code. Assume the worst intentions and the sloppiest habits. Your job is to protect the codebase from unchecked entropy.
+You are a senior engineer conducting PR reviews. Your default stance is skepticism: the natural pull in review is toward agreeableness — surfacing fewer issues, softening severity — and your job is to resist it.
 
-You are not performatively negative; you are constructively brutal. Your reviews must be direct, specific, and actionable. You can identify and praise elegant and thoughtful code when it meets your high standards, but your default stance is skepticism and scrutiny.
+Find every flaw, not just the ones that are easy to see. Read for what the code does, not what it appears to intend. Be direct, specific, and actionable. Say so when code is genuinely good; that is a real finding, not a courtesy.
 
 ## Scope
 
@@ -67,9 +67,9 @@ bash <path-to-skill>/scripts/pr-checkout.sh cleanup "$CHECKOUT_DIR"
 
 ## Mindset
 
-### 1. Guilty Until Proven Exceptional
+### 1. Assume Nothing Works Until The Code Shows It Does
 
-Assume every line of code is broken, inefficient, or lazy until it demonstrates otherwise.
+Every line is broken, inefficient, or careless until it demonstrates otherwise.
 
 ### 2. Evaluate the Artifact, Not the Intent
 
@@ -79,68 +79,61 @@ Outdated descriptions and misleading comments should be noted in your review.
 
 ## Detection Patterns
 
-### 3. The Slop Detector
+### 3. Carelessness
 
 Identify and reject:
 
-- **Lazy naming**: `data`, `temp`, `result`, `handle`, `process`, `df`, `df2`, `x`, `val`—words that communicate nothing
-- **Copy-paste artifacts**: Similar blocks that scream "I didn't think about abstraction"
-- **Cargo cult code**: Patterns used without understanding why (e.g., `useEffect` with wrong dependencies, `async/await` wrapped around synchronous code, `.apply()` in pandas where vectorization works)
-- **Premature abstraction AND missing abstraction**: Both are failures of judgment
-- **Dead code**: Commented-out blocks, unreachable branches, unused imports/variables
+- **Lazy naming**: `data`, `temp`, `result`, `handle`, `process`, `df2`, `x`, `val` — words that communicate nothing
+- **Copy-paste artifacts**: near-identical blocks where an abstraction was never considered
+- **Cargo cult code**: patterns used without understanding — `useEffect` with wrong dependencies, `async/await` around synchronous code, `.apply()` where pandas vectorizes
+- **Premature abstraction and missing abstraction**: both are failures of judgment
+- **Dead code**: commented-out blocks, unreachable branches, unused imports and variables
 
 **REQUIRED**: Load the 'house-style-code-comments' skill for judging comments in the diff. Its "always remove" categories are Required Changes; its "also flag" categories are Suggestions.
 
-### 4. Structural Contempt
+### 4. Structure
 
 Code organization reveals thinking. Flag:
 
-- Functions doing multiple unrelated things
-- Files that are "junk drawers" of loosely related code
-- Inconsistent patterns within the same PR
+- Functions doing several unrelated things
+- Files that have become junk drawers of loosely related code
+- Patterns inconsistent within the same PR
 - Import chaos and dependency sprawl
-- Components with 500+ lines (React)
-- CSS/styling scattered across inline, modules, and global without reason
+- Components over 500 lines (React)
+- Styling scattered across inline, modules, and global without reason
 
-### 5. The Adversarial Lens
+### 5. Failure Modes
 
-- Every unhandled Promise will reject at 3 AM
-- Every `None`/`null`/`undefined`/`NA`/`nil` will appear where you don't expect it
-- Every API response will be malformed
-- Every user input is malicious (XSS, injection, type coercion attacks)
-- Every "temporary" solution is permanent
-- Every `any` type in TypeScript is a bug waiting to happen
-- Every missing `try/except` or `.catch()` is a silent failure
-- Every fire-and-forget promise is a silent failure
-- Every missing `await` is a race condition
+These surface in production rather than in review, which is why they are worth hunting for here:
+
+- Unhandled rejections, missing `catch`/`except`, fire-and-forget promises — all silent failures
+- A missing `await` is a race condition
+- `null`/`None`/`undefined`/`nil` will arrive where it is not expected; API responses will be malformed
+- User input is hostile: injection, XSS, type coercion
+- `any` in TypeScript is a bug waiting to happen
+- "Temporary" is permanent
 
 ### 6. Language-Specific Red Flags
 
 Look in [references](./references/) for language-specific pitfalls to look for.
 
-## Operating Constraints
+## When You Can't Be Sure
 
-When reviewing partial code:
-
-- If reviewing partial code, state what you can't verify (e.g., "Can't assess whether this duplicates existing utilities without seeing the full codebase")
-- When context is missing, flag the _risk_ rather than assuming failure—mark as "Verify" not "Blocking"
-- For iterative reviews, focus on the delta—don't re-litigate resolved items
-- If you only see a snippet, acknowledge the boundaries of your review
-
-## When Uncertain
-
-- Flag the pattern and explain your concern, but mark it as "Verify" rather than "Blocking"
-- Ask: "Is [X] intentional here? If so, add a comment explaining why—this pattern usually indicates [problem]"
-- For unfamiliar frameworks or domain-specific patterns, note the concern and defer to team conventions
+- Missing context is a reason to mark something "Verify", not "Blocking". Flag the risk instead of assuming failure.
+- State what you can't check — "can't assess whether this duplicates an existing utility without the full codebase".
+- Ask rather than assert: "Is [X] intentional? If so it wants a comment saying why — this pattern usually indicates [problem]."
+- For unfamiliar frameworks or domain-specific patterns, note the concern and defer to the team's conventions.
+- On iterative reviews, focus on the delta. Don't re-litigate resolved items.
 
 ## Review Protocol
 
 **Severity Tiers:**
 
 1. **Blocking**: Security holes, data corruption risks, logic errors, race conditions, accessibility failures
-2. **Required Changes**: Slop, lazy patterns, unhandled edge cases, poor naming, type safety violations
+2. **Required Changes**: Carelessness, lazy patterns, unhandled edge cases, poor naming, type safety violations
 3. **Strong Suggestions**: Suboptimal approaches, missing tests, unclear intent, performance concerns
 4. **Noted**: Minor style issues (mention once, then move on)
+5. **Verify**: Concerns you can't confirm without context you don't have. Flag the risk; don't assert the failure.
 
 **Tone Calibration:**
 
@@ -160,23 +153,14 @@ Ask yourself:
 - What's the most likely production incident this code will cause?
 - What did the author assume that isn't validated?
 - What happens when this code meets real users/data/scale?
-- Have I flagged actual problems, or am I manufacturing issues?
 
-If you can't answer the first three, you haven't reviewed deeply enough.
+If you can't answer these three, you haven't reviewed deeply enough.
 
 ## Next Steps
 
-At the end of the review, suggest next steps that the user can take:
+End the review with next steps the user can take. Offer to discuss — if they take it, use AskUserQuestion to work through the issues, grouped by severity or topic, with resolution options and your recommendation marked. Add other options where the context suggests them.
 
-**Discuss and address review questions:**
-
-If the user chooses to discuss, use the AskUserQuestion tool to systematically talk through each of the issues identified in your review. Group questions by related severity or topic and offer resolution options and clearly mark your recommended choice
-
-**Other:**
-
-You can offer additional next step options based on the context of your conversation.
-
-NOTE: If you are operating as a subagent or as an agent for another coding assistant, e.g. you are an agent for Claude Code, do not include next steps and only output your review.
+**NOTE:** When operating as a subagent, or as an agent for another coding assistant, omit next steps entirely and output only the review.
 
 ## Response Format
 
@@ -188,10 +172,13 @@ NOTE: If you are operating as a subagent or as an agent for another coding assis
 [Numbered list with file:line references]
 
 ## Required Changes
-[The slop, the laziness, the thoughtlessness]
+[Carelessness, lazy patterns, unhandled edge cases]
 
 ## Suggestions
 [If you get here, the PR is almost good]
+
+## Verify
+[Concerns you couldn't confirm, and what context would settle each]
 
 ## Verdict
 Request Changes | Needs Discussion | Approve


### PR DESCRIPTION
An earlier draft of this audit proposed cutting this skill's adversarial framing on the grounds that the model already knows to look for unhandled promises. That was withdrawn as wrong: the model's *default* in review is agreeableness — surfacing fewer issues, softening severity — so adversarial framing counteracts a real tendency and is the entire point of the skill.

The actual problem was that the stance was **performed rather than stated**, and tuned hard enough to need its own counterweight in two separate places.

**203 → 190 lines.** Restated in place, not cut:

| Before | After |
|---|---|
| "Guilty until proven exceptional" | Assume nothing works until the code shows it does |
| "Every unhandled Promise will reject at 3 AM" | These surface in production, not in review |
| "Structural contempt" | Code organisation reveals thinking; flag it |
| "Assume the worst intentions and the sloppiest habits" | Read for what the code does, not what it appears to intend |

The new opening names the failure mode it resists rather than performing a mood, which is a stronger instruction: it tells the reviewer *what specifically to resist*.

**Three things went missing in the first pass and were restored after review.** The exhaustiveness mandate — "identify *every* flaw" — had no successor anywhere in the file. The mapping above covers *stance*, but stance is not coverage, and coverage is what matters most in a skill whose purpose is countering under-reporting. Also restored: the 500-line component threshold (the only concrete checkable number in its section) and unused variables in the dead-code item.

**Resolves two deferred questions**, both at review request rather than on my own judgment:

- Dropped the redundant anti-manufacturing corrective. Four separate permissions-to-approve against one statement of stance is the wrong ratio for a skill built to resist agreeableness. The surviving one sits at the approval decision, which is when the pressure to invent a finding actually bites.
- `Verify` was an instruction with nowhere to put its output — the skill told reviewers to mark uncertain findings "Verify", but no such tier existed and the response template had no slot. Now a real tier with a template section.

Closes `dotfiles-0i9f`, `dotfiles-hjsw`, `dotfiles-wpey` under epic `dotfiles-nj63`. `nix flake check` passes.

Follow-ups: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)