### PR TITLE
home/lib/ai: finish the Claude 5 rightsizing epic

### DIFF
--- a/.beans/dotfiles-e6kx--compress-devils-advocate-reference-files.md
+++ b/.beans/dotfiles-e6kx--compress-devils-advocate-reference-files.md
@@ -1,11 +1,11 @@
 ---
 # dotfiles-e6kx
 title: Compress devils-advocate reference files
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-08-15T15:33:00Z
-updated_at: 2026-08-15T15:33:10Z
+updated_at: 2026-08-16T09:24:03Z
 parent: dotfiles-nj63
 blocked_by:
     - dotfiles-nw9f
@@ -17,12 +17,20 @@ Lowest-confidence item in the epic: the references are already progressively dis
 
 Keep untouched:
 
-- [ ] SKILL.md calibration — the 7-concern cap, honest-severity definitions, the "so what?" test, steel-man-first. Calibration is exactly what a model cannot supply for itself
-- [ ] `references/ai-blind-spots.md` (326 lines) — the one reference that is not generic, and the most directly default-counteracting content in the repo
+- [x] SKILL.md calibration — the 7-concern cap, honest-severity definitions, the "so what?" test, steel-man-first. Calibration is exactly what a model cannot supply for itself
+- [x] `references/ai-blind-spots.md` (326 lines) — the one reference that is not generic, and the most directly default-counteracting content in the repo
 
 Compress:
 
-- [ ] `references/questioning-frameworks.md` (405 → ~80) — naming pre-mortem, inversion, and Socratic probing carries the value; explaining Five Whys and Six Thinking Hats at length does not
-- [ ] `references/blind-spots.md` (337 → ~80) — keep the 11 categories as a checklist, cut the exposition
+- [x] `references/questioning-frameworks.md` (405 → ~80) — naming pre-mortem, inversion, and Socratic probing carries the value; explaining Five Whys and Six Thinking Hats at length does not
+- [x] `references/blind-spots.md` (337 → ~80) — keep the 11 categories as a checklist, cut the exposition
 
 - [ ] Run `nix flake check`
+
+## Summary of Changes
+
+Compressed the two generic devils-advocate references; kept the calibration untouched.
+
+- `references/questioning-frameworks.md` (405 → 97): steel-manning, pre-mortem, inversion, the six Socratic probes, and reverse five whys survive as their operative move plus their question banks — which is where the value is. The long expositions of Five Whys and Six Thinking Hats are gone; the useful hats (missing data, alternatives, process) remain as a short 'other lenses' list.
+- `references/blind-spots.md` (337 → 48): all 11 categories kept as a checklist — lead question plus the concrete misses to look for — with the 'Why It's Missed' exposition and per-category question tables cut.
+- `SKILL.md` and `references/ai-blind-spots.md` calibration untouched, except one pointer line that still advertised 'Six Thinking Hats' as a named section.

--- a/.beans/dotfiles-m7np--collapse-maintaining-project-context.md
+++ b/.beans/dotfiles-m7np--collapse-maintaining-project-context.md
@@ -1,11 +1,11 @@
 ---
 # dotfiles-m7np
 title: Collapse maintaining-project-context
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-08-15T15:33:00Z
-updated_at: 2026-08-15T15:33:10Z
+updated_at: 2026-08-16T09:23:46Z
 parent: dotfiles-nj63
 blocked_by:
     - dotfiles-nw9f
@@ -15,7 +15,15 @@ blocked_by:
 
 The When-to-Update table (48–59), the step-by-step process (61–130), the Decision Tree (132–152), and the Quick Reference (154–169) are four renderings of one rule: *update context files when contracts change, not when implementation changes*. It also re-derives `writing-claude-md-files` content despite declaring it a required sub-skill.
 
-- [ ] Keep the AGENTS.md-vs-CLAUDE.md format detection and companion-pointer convention — non-obvious, repo-specific, unrecoverable from context
-- [ ] Collapse the four duplicate renderings into one paragraph plus the git-diff commands
-- [ ] Drop content that `writing-claude-md-files` owns (templates, freshness dates, the <100-line budget); rely on the declared sub-skill
+- [x] Keep the AGENTS.md-vs-CLAUDE.md format detection and companion-pointer convention — non-obvious, repo-specific, unrecoverable from context
+- [x] Collapse the four duplicate renderings into one paragraph plus the git-diff commands
+- [x] Drop content that `writing-claude-md-files` owns (templates, freshness dates, the <100-line budget); rely on the declared sub-skill
 - [ ] Run `nix flake check`
+
+## Summary of Changes
+
+Collapsed `maintaining-project-context/SKILL.md` from 182 to 46 lines.
+
+The When-to-Update table, the four-step process, the Decision Tree, the Quick Reference, and the Common Mistakes table were five renderings of one rule; that rule is now stated once in Core Principle ("update when contracts change, not when implementation changes") with the change taxonomy inline.
+
+Kept the non-recoverable, repo-specific parts: AGENTS.md-vs-CLAUDE.md format detection, the companion-pointer convention, the git-diff commands, and the lowest-level-that-applies hierarchy rule. Dropped templates, freshness dates, and the line budget — `writing-claude-md-files` is the declared sub-skill and owns them.

--- a/.beans/dotfiles-nj63--rightsize-ai-skills-for-claude-5-context-engineeri.md
+++ b/.beans/dotfiles-nj63--rightsize-ai-skills-for-claude-5-context-engineeri.md
@@ -1,10 +1,11 @@
 ---
 # dotfiles-nj63
 title: Rightsize AI skills for Claude 5 context engineering
-status: todo
+status: completed
 type: epic
+priority: normal
 created_at: 2026-08-15T15:30:44Z
-updated_at: 2026-08-15T15:30:44Z
+updated_at: 2026-08-16T09:24:21Z
 ---
 
 **Goal:** Rework `home/lib/ai/` skills and the claude-code skill-reinforcement hook against Anthropic's Claude 5 context-engineering guidance, cutting ~54% of directive lines without losing behaviour that is actually load-bearing.
@@ -29,3 +30,19 @@ Plus two independent grounds: **factually stale** (4.x-calibrated guidance now w
 
 - Skills deploy to `~/.claude/skills/<name>/` on **every machine this flake is applied to** and run against arbitrary projects. A skill may reference only files shipped inside its own directory — repo-relative paths dangle silently elsewhere.
 - `nix flake check` is the gate (nixfmt + skill-name conflict assertions).
+
+## Summary of Changes
+
+All 12 child beans completed. `home/lib/ai/` markdown is down from 2,891 to 1,803 lines (~38%), plus the skill-reinforcement hook no longer fires on every prompt.
+
+Landed across the epic:
+
+- Disabled the skill-reinforcement hook by default (retained, not deleted)
+- `coding-effectively` trimmed to rules; `house-style-code-comments` extracted as the single owner of the comment policy
+- `writing-claude-directives` rewritten for Claude 5; `critical-code-reviewer` restated plainly, with the Verify marker and the anti-manufacturing correctives reconciled
+- `global-instructions` rewritten as three rules of intent instead of scripted utterances
+- `maintaining-project-context` collapsed (182 → 46); `writing-claude-md-files` trimmed (301 → 108)
+- `devils-advocate` references compressed (1,068 → 588 across the three), calibration untouched
+- `brainstorming` and `writing-plans` rituals cut; `diff-scope` left alone
+
+Every cut was justified against the epic's criteria — taste over consensus, counteracts-a-default over restates-one, and cost-to-say — not against "Claude already knows this".

--- a/.beans/dotfiles-o58n--trim-brainstorming-and-writing-plans-rituals.md
+++ b/.beans/dotfiles-o58n--trim-brainstorming-and-writing-plans-rituals.md
@@ -1,11 +1,11 @@
 ---
 # dotfiles-o58n
 title: Trim brainstorming and writing-plans rituals
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-08-15T15:33:00Z
-updated_at: 2026-08-15T15:33:10Z
+updated_at: 2026-08-16T09:23:46Z
 parent: dotfiles-nj63
 blocked_by:
     - dotfiles-nw9f
@@ -15,8 +15,16 @@ blocked_by:
 
 Both are mostly keeps — the HARD-GATE is a deliberate workflow guardrail (the article preserves strategic guardrails), and the plannotator/beans invocations are mechanism, which self-documenting-interface guidance says to keep.
 
-- [ ] `brainstorming` — cut Key Principles (120–127), which restates the Process section
-- [ ] `writing-plans` — cut the announcement ritual (line 14), an artifact of the 4.x structural-enforcement playbook
-- [ ] `writing-plans` — cut the Remember section (237–243), which restates Bite-Sized Granularity and No Placeholders
-- [ ] Leave `diff-scope` untouched — it is already the model of what the guidance asks for
+- [x] `brainstorming` — cut Key Principles (120–127), which restates the Process section
+- [x] `writing-plans` — cut the announcement ritual (line 14), an artifact of the 4.x structural-enforcement playbook
+- [x] `writing-plans` — cut the Remember section (237–243), which restates Bite-Sized Granularity and No Placeholders
+- [x] Leave `diff-scope` untouched — it is already the model of what the guidance asks for
 - [ ] Run `nix flake check`
+
+## Summary of Changes
+
+Cut three 4.x-era rituals, left the mechanism alone.
+
+- `brainstorming` (127 → 118): removed the Key Principles list, which restated the Process section verbatim. HARD-GATE and the plannotator integration untouched.
+- `writing-plans` (243 → 233): removed the announcement ritual ("I'm using the writing-plans skill...") and the Remember section, which restated Bite-Sized Granularity and No Placeholders.
+- `diff-scope` untouched, as specified.

--- a/.beans/dotfiles-p4l3--trim-writing-claude-md-files.md
+++ b/.beans/dotfiles-p4l3--trim-writing-claude-md-files.md
@@ -1,11 +1,11 @@
 ---
 # dotfiles-p4l3
 title: Trim writing-claude-md-files
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-08-15T15:33:00Z
-updated_at: 2026-08-15T15:33:10Z
+updated_at: 2026-08-16T09:24:03Z
 parent: dotfiles-nj63
 blocked_by:
     - dotfiles-nw9f
@@ -17,14 +17,24 @@ Two full templates, a ~45-line synthetic auth example, then a Common Mistakes ta
 
 Keep:
 
-- [ ] Top-level vs subdirectory distinction (the actual insight)
-- [ ] The section lists
-- [ ] Freshness-date requirement with `date +%Y-%m-%d` — a real hallucination guard; models will invent a date
-- [ ] The no-`@`-syntax rule — a real, non-obvious token cost
+- [x] Top-level vs subdirectory distinction (the actual insight)
+- [x] The section lists
+- [x] Freshness-date requirement with `date +%Y-%m-%d` — a real hallucination guard; models will invent a date
+- [x] The no-`@`-syntax rule — a real, non-obvious token cost
 
 **Do NOT point at repo files.** Replacing the synthetic example with a pointer to `home/lib/ai/CLAUDE.md` or `crates/CLAUDE.md` was explicitly rejected: `mkSkillFiles` deploys this skill to `~/.claude/skills/` on every machine the flake is applied to, and it runs in arbitrary projects. Those paths exist nowhere else and fail silently.
 
-- [ ] Cut the two templates and the Common Mistakes table (both restate the section lists)
-- [ ] Keep one compact synthetic example, self-contained in the file, roughly a third of the current auth walkthrough
-- [ ] Cut the Checklist — with templates gone, the section lists serve that purpose
+- [x] Cut the two templates and the Common Mistakes table (both restate the section lists)
+- [x] Keep one compact synthetic example, self-contained in the file, roughly a third of the current auth walkthrough
+- [x] Cut the Checklist — with templates gone, the section lists serve that purpose
 - [ ] Run `nix flake check`
+
+## Summary of Changes
+
+Trimmed `writing-claude-md-files/SKILL.md` from 301 to 108 lines.
+
+Cut the two full templates, the Common Mistakes table, the top-level-vs-subdirectory heuristics table, and the Checklist — all four restated the section lists. The ~45-line auth example is now a ~30-line one, self-contained in the file, with a closing note on what its Purpose section deliberately does *not* say.
+
+Kept the load-bearing content: the top-level (HOW) vs subdirectory (WHY/contracts) distinction, both section lists, the mandatory freshness date with `date +%Y-%m-%d` as a hallucination guard, the no-`@`-syntax rule, and the line budgets.
+
+No repo-relative paths introduced — the example stays synthetic, since this skill deploys to `~/.claude/skills/` on every machine and runs in arbitrary projects.

--- a/home/lib/ai/skills/brainstorming/SKILL.md
+++ b/home/lib/ai/skills/brainstorming/SKILL.md
@@ -116,12 +116,3 @@ Plannotator's home-manager hook auto-fires only on `ExitPlanMode`. The two `plan
 Once the final-spec review returns `approved`, invoke the `writing-plans` skill. It will detect whether `beans` is on `$PATH` and either emit a beans hierarchy (epic → feature → task) or write a markdown plan to `docs/specs/plans/`.
 
 Do NOT invoke any other implementation skill from this skill.
-
-## Key Principles
-
-- **One question at a time** — don't overwhelm with multiple questions
-- **Multiple choice preferred** — easier to answer than open-ended when possible
-- **YAGNI ruthlessly** — remove unnecessary features from all designs
-- **Explore alternatives** — always propose 2–3 approaches before settling
-- **Incremental validation** — present design, get approval before moving on
-- **Be flexible** — go back and clarify when something doesn't make sense

--- a/home/lib/ai/skills/devils-advocate/SKILL.md
+++ b/home/lib/ai/skills/devils-advocate/SKILL.md
@@ -102,7 +102,7 @@ What to do:
 
 Read these as needed — don't load all upfront:
 
-- **`references/questioning-frameworks.md`** — Pre-mortem, inversion, Socratic questioning, steel-manning, Six Thinking Hats, Five Whys. Read this for structured approaches to challenging decisions.
+- **`references/questioning-frameworks.md`** — Steel-manning, pre-mortem, inversion, the six Socratic probes, reverse five whys — plus the question banks for each. Read this for structured approaches to challenging decisions.
 
 - **`references/blind-spots.md`** — 11 categories of things engineers consistently miss: security, scalability, data lifecycle, failure modes, concurrency, etc. Read this when reviewing code or architecture.
 

--- a/home/lib/ai/skills/devils-advocate/references/blind-spots.md
+++ b/home/lib/ai/skills/devils-advocate/references/blind-spots.md
@@ -1,337 +1,47 @@
 # Engineering Blind Spots
 
-Categories of issues that engineers consistently miss during design, implementation, and review. For each category: what it is, why it gets missed, key questions to surface it, and concrete examples.
+Eleven categories engineers consistently miss. Run the list as a checklist: for each, ask the lead question, and use the named misses as the concrete things to go looking for.
 
----
+## 1. Security — "Can user A access user B's data by manipulating the request?"
 
-## 1. Security
+Broken object-level authorization (authenticated but not *authorized* for that entity ID) is the top API vulnerability. Also: mass assignment (`{"role": "admin"}` in a profile update), verbose errors leaking stack traces and SQL, sequential IDs that invite enumeration, secrets in log lines, missing rate limits, unvalidated input size/encoding, missing security headers, endpoints triggerable cross-site (CSRF/SSRF), and dependencies with known CVEs.
 
-### Why It's Missed
+## 2. Scalability — "What happens at 100x current scale?"
 
-Security is invisible when it works. Engineers optimize for functionality — "does it do the thing?" — and security failures only manifest under adversarial conditions that normal testing doesn't simulate. Security thinking requires assuming malicious intent, which is psychologically unnatural for builders.
+Failures here are nonlinear: 50ms at 1k rows is 30s at 1M. Look for N+1 queries, unbounded `SELECT` with no LIMIT, missing pagination, filter columns with no index (invisible until the table grows), cache stampede on expiry, and nested loops that become quadratic. Ask what fails *first* at 10x traffic, which key or partition is hot, and what it costs.
 
-### Key Questions
+## 3. Data lifecycle — "If we delete this user, what happens to their data everywhere?"
 
-| Area | Question |
-|------|----------|
-| Authentication | "What happens if the JWT is expired but the request is already in flight?" |
-| Authorization | "Can user A access user B's resources by changing the ID in the URL?" |
-| Input validation | "What happens if this field contains 10MB of data? SQL? JavaScript? Unicode control characters?" |
-| Data exposure | "What fields in this API response should the requesting user NOT see?" |
-| Secrets | "If this log line is captured, does it contain anything sensitive?" |
-| CSRF/SSRF | "Can this endpoint be triggered by a malicious page the user visits?" |
-| Rate limiting | "What's the cost if someone calls this endpoint 10,000 times per second?" |
-| Dependency | "When was the last security audit of this dependency? Does it have known CVEs?" |
+Creation and reads get attention; retention and deletion don't. Right-to-erasure gaps are the classic: user removed from `users`, still present in `audit_log`, `analytics_events`, `email_log`, exports, and third-party integrations. Also orphaned records, soft-delete applied inconsistently across queries (deleted rows leak into some results), PII captured in structured logs, no retention policy at all, and no clean line between current state and historical snapshot.
 
-### Common Misses
+## 4. Integration points — "What happens when this dependency is down for an hour?"
 
-- **Broken object-level authorization (BOLA):** The #1 API vulnerability. Endpoint checks authentication but not whether the authenticated user owns the requested resource. Every endpoint that takes an entity ID must verify ownership.
-- **Mass assignment:** Accepting all fields from request body and passing to ORM update. User sends `{"role": "admin"}` in a profile update.
-- **Verbose error messages:** Stack traces, SQL errors, or internal paths in production API responses.
-- **Insecure direct object references:** Sequential integer IDs that allow enumeration. User iterates `/api/invoices/1`, `/api/invoices/2`, etc.
-- **Missing security headers:** No CSP, no HSTS, no X-Frame-Options in responses.
+Mocked in dev, flaky in prod. Check timeouts (a 30s-or-infinite default blocks threads and cascades), missing circuit breakers, retry safety/idempotency, strict deserialization that breaks on any upstream field change, rate limits, token expiry and refresh failure, and whether there's any fallback or graceful degradation. Webhooks arrive duplicated, out of order, and hours late — never assume once-and-in-order.
 
----
+## 5. Failure modes — "If step 3 of 5 fails, what state is the system in?"
 
-## 2. Scalability
+`catch (e) { log(e) }` is not error handling. Look for partial-operation inconsistency with no compensation (order created, payment never charged), retry storms without exponential backoff and jitter, silent failures where the system looks healthy but produces wrong results, useless error text, poison messages blocking a queue, and dead-letter queues nobody monitors. Ask whether recovery is self-healing or manual.
 
-### Why It's Missed
+## 6. Concurrency — "If two users do this at the exact same time, what happens?"
 
-Systems that work at current scale feel correct. Engineers test with small datasets and low concurrency. The mental model of "it works" is formed at development scale and rarely updated. Scaling failures are nonlinear — a query that takes 50ms with 1,000 rows takes 30 seconds with 1,000,000.
+Non-deterministic, so tests pass. Check-then-act without a lock (`if not exists: create`) lets both requests through. Lost updates: two reads of 100, both add 50, both write 150. Counter drift from read-modify-write instead of atomic increment. Double-submit with no idempotency key. Locks held across I/O, deadlock ordering, and connection-pool exhaustion from long transactions.
 
-### Key Questions
+## 7. Environment gaps — "What's different about production that we're not testing?"
 
-| Area | Question |
-|------|----------|
-| Data growth | "What happens to this query when the table has 10M rows? 100M?" |
-| Traffic | "If traffic increases 10x, which component fails first?" |
-| Storage | "How much storage does this consume per user per month? What's the projection?" |
-| Cardinality | "How many distinct values will this column/index/cache key have?" |
-| Fan-out | "How many downstream calls does a single user action trigger?" |
-| Cost | "What's the cloud cost of this at 100x current usage?" |
-| Hotspots | "Is there a single row, key, or partition that gets disproportionate traffic?" |
+Config values, data volume, network latency and DNS behaviour, service-account permissions, secret management, resource limits, pinned vs. floating dependency versions, feature-flag state. Concretely: timezone set by a cloud default, `/tmp` assumed unlimited but capped at 512MB, TLS only in prod, and missing env vars that dev papers over with defaults — crashing at startup, or worse, silently using the wrong value.
 
-### Common Misses
+## 8. Observability — "Can the on-call engineer debug this at 3am with what exists?"
 
-- **N+1 queries:** Fetching a list then querying each item individually. Works with 10 items, catastrophic with 10,000.
-- **Unbounded queries:** `SELECT * FROM table` with no LIMIT. Works in dev (100 rows), OOM in production (10M rows).
-- **Missing pagination:** Endpoints that return all results. Fine until the dataset grows.
-- **Full table scans disguised by small data:** Missing index on a filter column. Invisible until the table grows.
-- **Cache stampede:** Cache expires, 1,000 concurrent requests all miss cache and hit database simultaneously.
-- **Linear algorithms on growing data:** O(n) loops that become O(n^2) when nested or applied to growing collections.
+Zero user-facing value until it's the only thing that matters. Watch for log-and-pray (logs nobody queries, no alerts, no runbook), no correlation ID to trace a request across services, metric cardinality explosions from user-ID tags, alert fatigue burying real alerts, and technical metrics without business metrics — infrastructure green while orders-per-minute is zero.
 
----
+## 9. Deployment — "Can we roll this back in 5 minutes without data loss?"
 
-## 3. Data Lifecycle
+The blind spot is *during*, not before/after. Non-reversible migrations break rollback because old code expects the old column. Also: breaking API changes without versioning (client and server briefly disagree), stale caches serving the old response format, session loss on blue/green switchover, and `ALTER` under load locking a table until everything times out. Ask whether the feature can be turned off without a deploy.
 
-### Why It's Missed
+## 10. Multi-tenancy — "Does every query filter by tenant, including this new one?"
 
-Engineers focus on data creation and reading. The full lifecycle — creation, transformation, archival, deletion, compliance — is rarely considered upfront. Data deletion is especially neglected because it has no immediate user-facing value.
+Owned by no single feature, touches all of them; each feature is correct in isolation. One missed `tenant_id` is a cross-tenant leak. Also unnamespaced cache keys (`user:123` collides across tenants), global rate limits where one tenant's burst blocks everyone, tenant rules hardcoded in if-statements, and background jobs that leak tenant context from one iteration into the next.
 
-### Key Questions
+## 11. Edge cases — "What does this look like with zero data? Maximum data? Unicode?"
 
-| Area | Question |
-|------|----------|
-| Creation | "What validates this data at the point of entry? What if validation rules change?" |
-| Retention | "How long do we keep this? Is there a legal or business requirement?" |
-| Deletion | "If a user requests account deletion, what happens to their data across all tables?" |
-| Cascade | "If this record is deleted, what references it? Do foreign keys cascade or orphan?" |
-| PII | "Which fields in this table are personally identifiable? Can they be pseudonymized?" |
-| Backup | "If we restore from backup, does this data have consistency dependencies with other systems?" |
-| Migration | "If the schema changes, what happens to existing data? Is backfill needed?" |
-| Export | "Can the user export their data? In what format?" |
-
-### Common Misses
-
-- **Orphaned records:** Parent deleted, children remain with dangling foreign keys or no FK at all.
-- **Soft-delete inconsistency:** Some queries filter `deleted_at IS NULL`, others don't. Deleted data leaks into results.
-- **PII in logs:** Structured logging captures request bodies containing email, phone, address.
-- **No data retention policy:** Tables grow forever. Old data never archived or purged.
-- **GDPR right-to-erasure gaps:** User deleted from `users` table but their data persists in `audit_log`, `analytics_events`, `email_log`, exported CSVs, and third-party integrations.
-- **Temporal data confusion:** "Current" state mixed with historical state. No clear distinction between "active record" and "snapshot at time T."
-
----
-
-## 4. Integration Points
-
-### Why It's Missed
-
-Engineers test their own code, not the boundary between their code and external systems. Integrations work in dev (where the external system is mocked or always-available) and fail in production (where it's flaky, slow, or returns unexpected responses).
-
-### Key Questions
-
-| Area | Question |
-|------|----------|
-| Availability | "What happens when this dependency is down for 30 minutes? 4 hours?" |
-| Latency | "What if this API call takes 30 seconds instead of 200ms?" |
-| Response shape | "What if the response includes fields we don't expect? Or is missing fields we do?" |
-| Versioning | "What happens if the third-party API changes without notice?" |
-| Rate limits | "Does this integration have rate limits? What happens when we hit them?" |
-| Retry safety | "Is this operation idempotent? What happens if we retry and the first attempt actually succeeded?" |
-| Blast radius | "If this integration fails, what else breaks? Can we degrade gracefully?" |
-| Authentication | "When does the API token expire? What refreshes it? What if refresh fails?" |
-
-### Common Misses
-
-- **Timeout misconfiguration:** Default HTTP timeout of 30s or infinity. A slow dependency blocks threads, cascading to full system unavailability.
-- **No circuit breaker:** Failed dependency called repeatedly, consuming resources and slowing everything.
-- **Webhook delivery assumptions:** Assuming webhooks arrive once, in order, and promptly. In reality: duplicates, out-of-order, delayed by hours.
-- **Schema coupling:** Deserializing the entire response into a strict type. Any field addition or type change in the external API causes failures.
-- **Missing fallback:** No cached/default response when integration is unavailable. Feature becomes completely non-functional.
-
----
-
-## 5. Failure Modes
-
-### Why It's Missed
-
-Engineers think in terms of success paths. Failure handling is added as an afterthought — often just `catch (e) { log(e) }` — without considering the taxonomy of failures and appropriate responses for each.
-
-### Key Questions
-
-| Area | Question |
-|------|----------|
-| Partial failure | "What if step 3 of 5 fails? What state is the system in?" |
-| Retry behavior | "If this is retried, is the result identical? Or do we get duplicates?" |
-| Error propagation | "Does this error bubble up clearly, or does it get swallowed and surface as a confusing symptom elsewhere?" |
-| Poison messages | "What if one message in the queue is malformed? Does it block all processing?" |
-| Resource exhaustion | "What happens when disk is full? Memory is exhausted? Connection pool is depleted?" |
-| Cascading failure | "If this component fails, what other components fail as a result?" |
-| Recovery | "After the failure is resolved, does the system self-heal or require manual intervention?" |
-
-### Common Misses
-
-- **Inconsistent state from partial operations:** Multi-step process (create order, charge payment, send email) fails at step 2. Order exists, payment didn't happen, but there's no compensation logic.
-- **Retry storms:** Service A retries failed calls to Service B. Service B was failing due to overload. Retries make it worse. Exponential backoff with jitter is missing.
-- **Silent failures:** Exception caught and logged but not propagated. System appears healthy while producing wrong results.
-- **Error message uselessness:** `"An error occurred"` with no context about what failed, why, or what the user can do about it.
-- **Deadletter neglect:** Failed messages go to a dead letter queue that nobody monitors. Data is silently lost.
-
----
-
-## 6. Concurrency
-
-### Why It's Missed
-
-Developers write and test code sequentially. Concurrency bugs are non-deterministic — they depend on timing, load, and scheduling. A race condition that occurs 1 in 10,000 times passes all tests and only manifests in production under load.
-
-### Key Questions
-
-| Area | Question |
-|------|----------|
-| Race conditions | "If two users do this simultaneously, what happens?" |
-| Double-submit | "If the user clicks the button twice quickly, do we create two records?" |
-| Read-modify-write | "Between reading this value and writing the update, can another process change it?" |
-| Locking | "What's the lock granularity? Are we holding locks during I/O?" |
-| Deadlock | "Can two processes each hold a lock the other needs?" |
-| Ordering | "Does this code assume events arrive in order? What if they don't?" |
-| Idempotency | "If this operation runs twice with the same input, is the result the same?" |
-
-### Common Misses
-
-- **Check-then-act without locking:** `if not exists(email): create_user(email)` — two concurrent requests both pass the check, both create the user.
-- **Lost updates:** Two requests read balance=100, both add 50, both write 150. Expected: 200. Use optimistic locking (version column) or `UPDATE ... SET balance = balance + 50`.
-- **Double-submit on forms:** User clicks "Submit" twice. Two identical records created. No idempotency key, no client-side guard.
-- **Counter drift:** `count = get_count(); set_count(count + 1)` instead of atomic `INCREMENT`. Under concurrency, counts drift downward.
-- **Connection pool exhaustion:** Long-running transactions or leaked connections deplete the pool. New requests queue and timeout.
-
----
-
-## 7. Environment Gaps
-
-### Why It's Missed
-
-"Works on my machine" is the canonical expression of this blind spot. Development environments differ from production in ways that are invisible until they cause failures: different OS, different resource limits, different network topology, different data volume.
-
-### Key Questions
-
-| Area | Question |
-|------|----------|
-| Configuration | "Which config values differ between dev, staging, and production?" |
-| Data volume | "Dev has 100 rows. Production has 10M. Have we tested with production-scale data?" |
-| Network | "Does this assume localhost latency? What about cross-region calls in prod?" |
-| Permissions | "Does the prod service account have the same permissions as the dev user?" |
-| Secrets | "How are secrets managed in production? Are they the same as dev?" |
-| Resource limits | "What are the memory/CPU/disk limits in production? Have we tested at those limits?" |
-| Dependencies | "Are all dependency versions pinned? Could a `latest` tag differ between environments?" |
-| Feature flags | "What flags are enabled in prod that aren't in dev, or vice versa?" |
-
-### Common Misses
-
-- **Timezone differences:** Dev machine is UTC, production is UTC, but the database server was configured in a different timezone by the cloud provider's default.
-- **File system assumptions:** Code writes to `/tmp` expecting unlimited space. Production container has a 512MB tmpfs.
-- **DNS resolution:** Local dev resolves service names instantly. Production DNS has TTLs, caching, and occasional failures.
-- **SSL/TLS in production only:** Dev uses HTTP. First production deploy fails because the app doesn't trust the CA, or redirects break.
-- **Missing environment variables:** App starts fine in dev (defaults used). Production has no defaults and crashes on startup — or worse, silently uses wrong values.
-
----
-
-## 8. Observability
-
-### Why It's Missed
-
-Observability is not a feature users see. It has zero user-facing value until something breaks — then it's the most important thing. Engineers under time pressure deprioritize it because it doesn't show up in demos.
-
-### Key Questions
-
-| Area | Question |
-|------|----------|
-| Debugging | "If this fails in production at 3am, what information does the on-call engineer have?" |
-| Logging | "Are log messages structured? Do they include correlation IDs, user IDs, and context?" |
-| Metrics | "What metrics tell us this system is healthy? What threshold means 'unhealthy'?" |
-| Alerting | "What alerts fire if this breaks? Are they actionable or just noise?" |
-| Tracing | "Can we trace a user request across all services it touches?" |
-| Dashboards | "Is there a dashboard for this feature? Does anyone actually look at it?" |
-| Cost | "Do we know the per-request cost of this operation? Can we detect cost anomalies?" |
-
-### Common Misses
-
-- **Log and pray:** Logging exists but no one queries it. No alerts, no dashboards, no runbooks.
-- **Missing request correlation:** No way to trace a single user request through multiple services and database calls.
-- **Metric cardinality explosion:** Metrics tagged with user ID or request ID. Monitoring system overwhelmed.
-- **Alert fatigue:** Too many non-actionable alerts. On-call ignores them all. Real alerts get lost in noise.
-- **No business metrics:** Technical metrics (CPU, memory, latency) exist but no one tracks business metrics (orders per minute, conversion rate). A business failure with healthy infrastructure goes undetected.
-
----
-
-## 9. Deployment
-
-### Why It's Missed
-
-Deployment is treated as "push code, it's live." The transition period — where old code and new code coexist, where migrations run, where caches contain old data — is rarely considered. Engineers think in terms of "before" and "after," not "during."
-
-### Key Questions
-
-| Area | Question |
-|------|----------|
-| Rollback | "Can we roll back this deployment in under 5 minutes? What breaks if we do?" |
-| Migration | "Is this migration backward-compatible? Can old code work with the new schema?" |
-| In-flight requests | "What happens to requests that started before deployment and finish after?" |
-| Cache invalidation | "Do cached values still make sense after this deployment?" |
-| Feature flags | "Can this feature be turned off without a deployment?" |
-| Zero-downtime | "Is there a moment during deployment where the service is unavailable?" |
-| Dependency ordering | "Does this deployment require another service to be deployed first?" |
-
-### Common Misses
-
-- **Non-reversible migrations:** Column renamed or dropped. Rollback to previous code version fails because the old code expects the old column.
-- **Breaking API changes without versioning:** Frontend deployed before backend (or vice versa). Brief period where client and server disagree on the API contract.
-- **Stale caches:** Deployment changes response format. CDN/browser/application cache serves old format. Users see broken UI until cache expires.
-- **Blue/green session loss:** User is on the old instance with session state. Traffic switches to the new instance. Session gone.
-- **Database migration under load:** Migration locks a table for ALTER. All queries to that table queue and timeout. Application appears down.
-
----
-
-## 10. Multi-Tenancy
-
-### Why It's Missed
-
-Multi-tenancy is an architectural constraint that touches everything but is owned by no single feature. Each individual feature works correctly in isolation. The failures only appear when tenants interact — through shared resources, leaked data, or noisy neighbors.
-
-### Key Questions
-
-| Area | Question |
-|------|----------|
-| Data isolation | "If I remove the auth token and substitute a different tenant ID, do I see their data?" |
-| Query filtering | "Does every query in this feature filter by tenant? Including joins, subqueries, and aggregations?" |
-| Resource fairness | "Can one tenant's usage degrade performance for all others?" |
-| Configuration | "Is this hardcoded for one tenant, or configurable per tenant?" |
-| Background jobs | "Do background jobs set the tenant context? What if a job processes multiple tenants?" |
-| Caching | "Are cache keys namespaced by tenant? Can tenant A's cache return tenant B's data?" |
-| Logging | "If we search logs by tenant ID, do we get exactly and only their activity?" |
-
-### Common Misses
-
-- **Missing tenant filter in new queries:** Every new query must include `tenant_id`. One missed filter = cross-tenant data leak.
-- **Global caches:** Cache key `user:123` without tenant prefix. Two tenants with user ID 123 get each other's cached data.
-- **Shared rate limits:** Rate limit applied globally. One tenant's legitimate burst blocks all other tenants.
-- **Tenant-specific config as code:** Feature flag or business rule hardcoded in an if-statement instead of in tenant configuration.
-- **Background job context leakage:** Job processes tenant A, then tenant B, but the tenant context from A persists into B's processing.
-
----
-
-## 11. Edge Cases
-
-### Why It's Missed
-
-Edge cases are, by definition, not the common case. Engineers build for the typical user on the typical path. But edge cases are where bugs hide, where data corrupts, and where security vulnerabilities live. The edges of the input space are also where attackers operate.
-
-### Key Questions
-
-| Area | Question |
-|------|----------|
-| Empty state | "What does this look like with zero data? First-time user, empty list, no history?" |
-| Boundaries | "What happens at the maximum? Minimum? Exactly zero? Negative values?" |
-| Unicode | "What happens with emoji, RTL text, or characters outside ASCII?" |
-| Timezone | "What happens at midnight? What about midnight in different timezones? DST transitions?" |
-| Precision | "Are we using floats for money? What happens to rounding over millions of transactions?" |
-| Nulls | "Which of these fields can be null in practice, even if the schema says NOT NULL?" |
-| Ordering | "What if the list is empty? One item? Already sorted? Reverse sorted?" |
-
-### Common Misses
-
-- **Empty state panic:** Feature works beautifully with data. With no data: blank screen, undefined errors, or misleading "No results found" when the user hasn't searched yet.
-- **Integer overflow / float precision:** `0.1 + 0.2 !== 0.3` in IEEE 754. Currency calculations drift. Use integer cents or decimal types.
-- **Timezone-naive datetime:** Storing `datetime` without timezone info. Comparing timestamps from different sources produces wrong results around DST.
-- **Names and text assumptions:** Name field rejects O'Brien (unescaped apostrophe), Mller (umlaut), or (zero-width space). Max length of 50 rejects legitimate long names.
-- **Off-by-one in pagination:** Page 1 shows items 1-10, page 2 shows items 10-19 (item 10 duplicated) or items 12-21 (item 11 missing).
-- **Leap seconds, leap years, DST:** `February 29` breaks date validation. `2am on DST transition` doesn't exist (or exists twice). Scheduling logic fails.
-- **Maximum payload:** File upload with no size limit. User uploads 5GB file. Server runs out of memory.
-
----
-
-## Quick Reference: The Question That Catches Each Blind Spot
-
-| Blind Spot | Single Most Revealing Question |
-|------------|-------------------------------|
-| Security | "Can user A access user B's data by manipulating the request?" |
-| Scalability | "What happens at 100x current scale?" |
-| Data lifecycle | "If we delete this user, what happens to their data everywhere?" |
-| Integration | "What happens when this dependency is down for an hour?" |
-| Failure modes | "If step 3 of 5 fails, what state is the system in?" |
-| Concurrency | "If two users do this at the exact same time, what happens?" |
-| Environment | "What's different about production that we're not testing?" |
-| Observability | "Can the on-call engineer debug this at 3am with available tools?" |
-| Deployment | "Can we roll this back in 5 minutes without data loss?" |
-| Multi-tenancy | "Does every query filter by tenant, including this new one?" |
-| Edge cases | "What does this look like with zero data? Maximum data? Unicode?" |
+Empty state (blank screen or "no results" before the user has searched), boundaries (max, min, exactly zero, negative), floats for money (`0.1 + 0.2 !== 0.3` — use integer cents), timezone-naive datetimes and DST transitions that don't exist or happen twice, `Feb 29`, name fields that reject O'Brien or Müller or a 50-character legitimate name, off-by-one pagination duplicating or skipping an item, and uploads with no size cap.

--- a/home/lib/ai/skills/devils-advocate/references/questioning-frameworks.md
+++ b/home/lib/ai/skills/devils-advocate/references/questioning-frameworks.md
@@ -1,405 +1,97 @@
 # Questioning Frameworks
 
-Reference material for structured critical analysis of software decisions, code, plans, and architecture.
+Structured ways to interrogate a decision, plan, or diff. Each is a move, not a ceremony — take the questions, skip the workshop.
 
----
+## Steel-Manning — do this first, always
 
-## 1. Pre-Mortem Analysis (Gary Klein)
+Before critiquing, construct the best case FOR the approach: name the exact decision, list the constraints the author faced (time, backward compatibility, team expertise, existing patterns), then state what would have to be true for it to be optimal — "this is the right call IF...". Now check whether those conditions hold.
 
-### What It Is
-
-A pre-mortem assumes the project/decision has already failed and works backward to identify causes. Unlike a post-mortem (which happens after failure), a pre-mortem leverages prospective hindsight — the psychological finding that people are 30% better at identifying reasons for an outcome when they imagine it has already occurred.
-
-### When to Use
-
-- Before shipping a feature, migration, or architectural change
-- Before committing to a technical direction that's hard to reverse
-- When reviewing a plan that "feels right" but hasn't been stress-tested
-- Before any deployment with data migration or schema changes
-
-### Step-by-Step Process
-
-1. **Frame the failure.** State: "It is six months from now. This [feature/migration/decision] shipped and caused a serious incident. The team is in an emergency war room."
-2. **Generate failure stories independently.** Each participant (or each pass of analysis) writes specific failure scenarios — not vague risks, but narratives: "The migration ran for 47 minutes, exceeded the maintenance window, and left the database in an inconsistent state because..."
-3. **Identify the most plausible failures.** Rank by likelihood x impact. Focus on failures that are both plausible and would be embarrassing in retrospect ("we should have seen that coming").
-4. **Trace each failure to its root cause in the current plan.** What assumption, missing test, or unhandled case would have caused this?
-5. **Determine preventive actions.** For each plausible failure: what would you add, change, or test to prevent it?
-
-### Example Questions for Software Context
-
-| Scenario | Pre-Mortem Question |
-|----------|-------------------|
-| New API endpoint | "This endpoint caused a production outage. The on-call engineer's pager went off at 3am. What happened?" |
-| Database migration | "The migration failed halfway through on production. What was different about prod that we didn't account for?" |
-| Feature launch | "Users are furious. Support tickets tripled. What did we get wrong about how they'd actually use this?" |
-| Dependency upgrade | "The upgrade broke production silently — no errors, just wrong behavior. What changed that our tests didn't cover?" |
-| Performance optimization | "The optimization made things worse under real load. What about production traffic patterns did we miss?" |
-
-### Key Insight
-
-The power of pre-mortem is that it gives people permission to voice concerns they'd otherwise suppress. In code review, this translates to: "I'm not saying this is wrong, I'm saying IF it failed, here's how it would fail."
-
----
-
-## 2. Inversion (Charlie Munger)
-
-### What It Is
-
-Instead of asking "how do we succeed?", ask "what would guarantee failure?" then ensure none of those conditions exist. Munger's principle: "Invert, always invert." Many problems are easier to solve backward than forward.
-
-### When to Use
-
-- Evaluating whether a design is robust
-- Reviewing acceptance criteria — are they sufficient?
-- Assessing operational readiness
-- When a plan seems solid but you can't articulate specific concerns
-
-### Three-Step Process
-
-1. **Define the opposite goal.** If the goal is "reliable data processing pipeline," the inverse is "guaranteed data loss or corruption."
-2. **Enumerate ways to achieve the inverse.** Be thorough and specific:
-   - "Never validate input schemas"
-   - "Ignore partial failures and continue processing"
-   - "No idempotency keys on writes"
-   - "Deploy without rollback capability"
-   - "No monitoring on queue depth or processing lag"
-3. **Check the current plan against each item.** For every failure-guaranteeing condition, verify the plan actively prevents it. Any gap is a finding.
-
-### Example Applications
-
-**Inversion applied to authentication system:**
-
-| "To guarantee a security breach, we would..." | Check |
-|-----------------------------------------------|-------|
-| Store passwords in plaintext | Bcrypt/argon2 with salt? |
-| Never expire sessions | Token TTL + refresh rotation? |
-| Return different errors for "user not found" vs "wrong password" | Uniform error messages? |
-| Allow unlimited login attempts | Rate limiting + lockout? |
-| Send tokens in URL query parameters | Headers only, no logging? |
-| Trust client-side role claims | Server-side authorization on every request? |
-
-**Inversion applied to deployment:**
-
-| "To guarantee a failed deployment, we would..." | Check |
-|--------------------------------------------------|-------|
-| Deploy on Friday at 5pm with no rollback plan | Deployment windows + rollback runbook? |
-| Run migrations that can't be reversed | Backward-compatible migrations? |
-| Skip canary/staged rollout | Progressive deployment? |
-| Have no way to verify success post-deploy | Health checks + smoke tests? |
-| Depend on manual steps that aren't documented | Automated pipeline? |
-
-### Example Questions
-
-- "If we wanted to guarantee data corruption in this pipeline, what would we do? Now — are any of those conditions present?"
-- "What's the fastest way a malicious insider could exploit this? Do we prevent it?"
-- "If we wanted users to abandon this feature in frustration, what would the UX look like? Does ours resemble that?"
-- "What would make this system impossible to debug in production?"
-
----
-
-## 3. Socratic Questioning (Six Types)
-
-### What It Is
-
-Socratic questioning is a disciplined method of probing thinking through six categories of questions. It doesn't assert — it reveals gaps, assumptions, and contradictions by asking the right questions in sequence.
-
-### When to Use
-
-- During code review or design review
-- When evaluating a technical proposal
-- When someone (including yourself) is confident in an approach
-- To help surface implicit assumptions
-
-### The Six Types
-
-#### 3.1 Clarification Questions
-
-**Purpose:** Ensure the claim or decision is well-defined. Vague statements hide complexity.
-
-| Question | When to Use |
-|----------|-------------|
-| "What exactly do you mean by [term]?" | When jargon or ambiguous terms are used ("scalable," "robust," "simple") |
-| "Can you give a concrete example of how this would work?" | When the description is abstract |
-| "What's the specific user action that triggers this code path?" | When reviewing business logic |
-| "What does 'done' look like for this? What's the acceptance test?" | When scope is unclear |
-| "When you say 'handle errors gracefully,' what does the user see?" | When error handling is described but not specified |
-
-#### 3.2 Probing Assumptions
-
-**Purpose:** Surface and test beliefs taken for granted. Most design flaws stem from untested assumptions.
-
-| Question | When to Use |
-|----------|-------------|
-| "What are we assuming about the input data that might not hold?" | Data processing, API endpoints |
-| "Are we assuming this third-party service will always be available?" | Integration points |
-| "What if the user doesn't follow the expected flow?" | UI/UX decisions |
-| "Are we assuming the data fits in memory?" | Processing pipelines |
-| "What if this table grows 100x? Does the query plan still work?" | Database design |
-| "Are we assuming deploys happen with zero in-flight requests?" | Migration/deployment plans |
-| "Is there an assumption here about ordering or timing?" | Distributed systems, event processing |
-
-#### 3.3 Probing Evidence / Reasoning
-
-**Purpose:** Examine the basis for a claim. "How do we know this is true?"
-
-| Question | When to Use |
-|----------|-------------|
-| "What data supports this design choice?" | When a choice is presented as obvious |
-| "Has this pattern been tested under production-like conditions?" | Performance claims |
-| "Where did the requirement for [X] come from? Can we verify it?" | When building to assumed requirements |
-| "What's the evidence that users actually need this?" | Feature decisions |
-| "How do we know the current implementation is actually the bottleneck?" | Optimization efforts |
-
-#### 3.4 Questioning Perspectives / Viewpoints
-
-**Purpose:** Consider alternative angles. What would someone with a different role, context, or expertise think?
-
-| Question | When to Use |
-|----------|-------------|
-| "How would the on-call engineer experience this at 3am?" | Operational readiness |
-| "What would a new team member think when reading this code?" | Code clarity |
-| "How does this look from the attacker's perspective?" | Security review |
-| "What would the DBA say about this query pattern?" | Database usage |
-| "If we inherited this codebase, what would frustrate us?" | Code quality |
-| "What would the customer support team need when this breaks?" | Error handling, observability |
-
-#### 3.5 Probing Implications / Consequences
-
-**Purpose:** Follow the decision to its logical conclusion. What happens next? And after that?
-
-| Question | When to Use |
-|----------|-------------|
-| "If we do this, what does that commit us to maintaining?" | Architectural decisions |
-| "What's the migration path if this approach doesn't scale?" | Technology choices |
-| "If this succeeds wildly, what breaks first?" | Capacity planning |
-| "What becomes harder to change after we ship this?" | Reversibility assessment |
-| "What other teams or systems are affected by this change?" | Blast radius |
-| "If we add this column now, what does the migration look like in 2 years?" | Schema design |
-
-#### 3.6 Meta-Questions (Questions About the Question)
-
-**Purpose:** Examine the framing itself. Are we solving the right problem?
-
-| Question | When to Use |
-|----------|-------------|
-| "Why is this the question we're asking? Is there a better framing?" | When stuck or going in circles |
-| "Are we solving the symptom or the root cause?" | Bug fixes, workarounds |
-| "Is this actually our problem to solve, or should it be handled elsewhere?" | Scope/boundary decisions |
-| "What would we do if we couldn't use this approach at all?" | When fixated on one solution |
-| "Are we optimizing for the right metric?" | Performance/business decisions |
-
----
-
-## 4. Steel-Manning
-
-### What It Is
-
-Before criticizing a decision or approach, articulate the strongest possible version of why it's reasonable. This is the opposite of a straw man — you construct the best case FOR the approach, then evaluate whether your critique still holds.
-
-### Why It Matters for Calibration
-
-- Prevents knee-jerk "that's wrong" reactions that miss context
-- Forces you to understand the tradeoffs the author actually considered
-- Makes your eventual critique more credible and specific
-- Catches cases where the approach is actually correct and you're the one missing something
-
-### When to Use
-
-- Before every critique — this should be the default first step
-- When your instinct is "this is wrong" — that instinct is often right, but the steel-man ensures the critique is precise
-- When reviewing code from someone with more domain context than you
-
-### Step-by-Step Process
-
-1. **Identify the decision.** What specific choice was made? (Not a vague "this is bad" — name the exact decision.)
-2. **List the constraints the author faced.** Time pressure, backward compatibility, team expertise, existing patterns, business requirements.
-3. **Construct the best argument FOR this approach.** "This approach is reasonable because..."
-4. **Identify what would need to be true for this approach to be optimal.** "This is the right call IF..."
-5. **Now evaluate:** Are those conditions actually true? If not, what specifically changes?
-
-### Example
-
-**Decision:** A team chose to use polling instead of WebSockets for real-time updates.
-
-| Step | Analysis |
-|------|----------|
-| Steel-man | "Polling is simpler to implement, debug, and deploy. It works through all proxies and load balancers without special configuration. The team has no WebSocket experience, and the update frequency (every 30s) doesn't require true real-time. The operational cost of maintaining WebSocket connections at scale is non-trivial." |
-| Conditions | "This is optimal IF update latency of 30s is acceptable, IF the polling load is manageable at expected scale, IF there's no future requirement for sub-second updates." |
-| Evaluation | "The business requirement says 'near real-time' which the PM defined as <5s. 30s polling doesn't meet this. Additionally, at projected user count, polling creates 200 req/s that WebSockets would eliminate. The steel-man is strong on operational simplicity but breaks on the latency requirement." |
-
-### Example Questions
+This is not politeness. It catches the case where the approach is correct and you're the one missing context, and it makes the surviving critique specific enough to act on.
 
 - "What's the strongest argument for keeping this exactly as it is?"
 - "Under what conditions would this be the ideal approach?"
 - "What constraints made this the pragmatic choice?"
-- "If I had to defend this approach in a design review, what would I say?"
 - "What am I missing about the context that would make this reasonable?"
 
----
+## Pre-Mortem — assume it already failed
 
-## 5. Six Thinking Hats (Edward de Bono)
+Frame it as fact: "It is six months from now. This shipped and caused a serious incident." Then write specific failure *narratives*, not vague risks — "the migration ran 47 minutes, exceeded the maintenance window, and left the database inconsistent because...". Rank by likelihood × impact, trace each back to the assumption or missing test in the current plan, and name the preventive action.
 
-### What It Is
+The reframe matters: "IF this failed, here's how" surfaces concerns that "this is wrong" suppresses.
 
-A method for examining a decision from six distinct perspectives, one at a time. The value is in deliberate perspective-switching — most people default to one or two modes and ignore the rest.
+- New endpoint: "This caused an outage and paged someone at 3am. What happened?"
+- Migration: "It failed halfway on production. What was different about prod?"
+- Launch: "Users are furious, tickets tripled. What did we get wrong about how they'd use it?"
+- Dependency upgrade: "It broke production silently — no errors, wrong behaviour. What did our tests not cover?"
+- Optimization: "It made things worse under real load. What traffic pattern did we miss?"
 
-### When to Use
+## Inversion — what would guarantee failure?
 
-- When a decision has been made quickly and feels "obvious"
-- When a group is stuck in one mode of thinking (e.g., only discussing risks, or only discussing benefits)
-- For structured review of an architectural decision record (ADR)
+Define the opposite goal ("guaranteed data loss"), enumerate specific ways to achieve it, then verify the plan actively prevents each one. Every gap is a finding.
 
-### The Four Most Relevant Hats for Software Review
+For an auth system, the inverse list runs: store passwords in plaintext, never expire sessions, return different errors for unknown-user vs wrong-password, allow unlimited attempts, put tokens in query params, trust client-side role claims. For a deployment: no rollback plan, irreversible migrations, no staged rollout, no post-deploy verification, undocumented manual steps.
 
-#### Black Hat — Risks and Problems
+- "If we wanted to guarantee corruption in this pipeline, what would we do? Are any of those present?"
+- "What's the fastest way a malicious insider could exploit this?"
+- "What would make this impossible to debug in production?"
 
-The devil's advocate hat. What can go wrong?
+## Socratic Questioning — six probes
 
-**Process:** Assume this will fail. Enumerate every failure mode, risk, and weakness.
+**Clarification** — vague terms hide complexity.
+- "What exactly do you mean by scalable / robust / simple?"
+- "What does 'done' look like? What's the acceptance test?"
+- "When you say 'handle errors gracefully', what does the user actually see?"
 
-| Question | Focus |
-|----------|-------|
-| "What's the worst case if this fails?" | Impact assessment |
-| "Where is the single point of failure?" | Resilience |
-| "What happens when the dependency is down?" | Fault tolerance |
-| "What's the security attack surface?" | Security |
-| "Where will this be painful to maintain in a year?" | Technical debt |
+**Assumptions** — most design flaws are untested beliefs.
+- "What are we assuming about the input data that might not hold?"
+- "Are we assuming this third-party service is always available?"
+- "What if this table grows 100x — does the query plan still work?"
+- "Is there an assumption about ordering or timing here?"
 
-#### White Hat — Missing Data
+**Evidence** — how do we know this is true?
+- "What data supports this design choice?"
+- "Has this been tested under production-like conditions, or estimated?"
+- "How do we know the current implementation is actually the bottleneck?"
+- "Where did the requirement for X come from? Can we verify it?"
 
-What do we know? What don't we know? What do we need to find out?
+**Perspectives** — who else sees this?
+- "How does the on-call engineer experience this at 3am?"
+- "How does this look from the attacker's perspective?"
+- "What would a new team member think reading this code?"
+- "What does support need when this breaks?"
 
-**Process:** Strip away opinions and assumptions. Focus only on facts, data, and gaps.
+**Implications** — follow it forward.
+- "If we do this, what does it commit us to maintaining?"
+- "What becomes harder to change after we ship?"
+- "If this succeeds wildly, what breaks first?"
+- "What other systems are in the blast radius?"
 
-| Question | Focus |
-|----------|-------|
-| "What's the actual measured latency, not the expected?" | Real vs. assumed performance |
-| "How many users will actually hit this code path?" | Usage data |
-| "Do we have production data on error rates for this integration?" | Empirical evidence |
-| "What don't we know about the customer's usage pattern?" | Unknown unknowns |
-| "Have we load-tested this, or are we estimating?" | Data quality |
+**Meta** — is this the right question?
+- "Are we solving the symptom or the root cause?"
+- "Is this our problem to solve, or should it be handled elsewhere?"
+- "What would we do if we couldn't use this approach at all?"
+- "Are we optimizing for the right metric?"
 
-#### Green Hat — Alternatives
+## Reverse Five Whys — trace the decision to its motivation
 
-Creative exploration. What else could we do?
+Ask "why this approach?" repeatedly, moving from surface rationale → underlying concern → real vs. assumed constraint → whether that constraint is actually fixed → whether this is the best way to address the root concern. Use it when the rationale is "best practice" or "how we've always done it."
 
-**Process:** Generate options without judging them. Quantity over quality in this phase.
+It reliably exposes complex solutions aimed at symptoms: *microservices → independent deployability → different cadences → payments needs compliance review* — which a CI approval gate solves without splitting the architecture.
 
-| Question | Focus |
-|----------|-------|
-| "What if we didn't build this at all? What's the manual workaround?" | Necessity check |
-| "What's a completely different architecture that solves this?" | Fresh perspective |
-| "What would [company known for this] do?" | Pattern borrowing |
-| "What if we split this into two simpler problems?" | Decomposition |
-| "What's the simplest version that would still be useful?" | MVP thinking |
+## Other lenses worth a pass
 
-#### Blue Hat — Meta/Process
+- **Missing data** — separate measured from assumed: real latency, actual traffic on this path, production error rates, load-tested vs. estimated.
+- **Alternatives** — generate before judging: not building it at all, a different architecture, splitting it into two simpler problems, the simplest version that's still useful.
+- **Process** — are we spending time on the highest-risk area? What decision are we actually making? How will we know which option was better?
 
-Thinking about the thinking. Are we asking the right questions?
+## Recommended sequence
 
-**Process:** Step back from the content. Evaluate the quality of the analysis itself.
+Steel-man → clarify → reverse five whys → inversion → pre-mortem → implications. Understanding before challenge: it builds the credibility that makes the critique land, and it filters out stylistic preferences before they reach the user.
 
-| Question | Focus |
-|----------|-------|
-| "Have we talked to the people who'll actually use/maintain this?" | Stakeholder coverage |
-| "Are we spending time on the highest-risk areas?" | Prioritization |
-| "What decision are we actually making right now?" | Scope clarity |
-| "Do we have the right people in this discussion?" | Expertise coverage |
-| "What's our decision criteria? How will we know which option is better?" | Framework |
-
-### How to Apply Sequentially
-
-When reviewing a decision or plan:
-
-1. **Blue** (2 min): What are we evaluating? What matters most?
-2. **White** (5 min): What do we actually know? What data is missing?
-3. **Green** (5 min): What alternatives exist? (List without judging.)
-4. **Black** (10 min): What can go wrong with the proposed approach?
-5. **Steel-man** (3 min): What's the strongest case FOR this approach?
-6. **Blue** (2 min): Given all of this, what's our recommendation?
-
----
-
-## 6. Five Whys (Reverse Application)
-
-### What It Is
-
-The classic Five Whys traces from a problem backward to its root cause. In reverse application for decision review, you trace from a decision backward to its underlying motivation — exposing whether the stated rationale actually supports the choice.
-
-### When to Use
-
-- When reviewing a design decision that feels like it was made by convention
-- When the rationale is "this is how we've always done it" or "this is best practice"
-- When a technical choice seems disconnected from the actual problem
-
-### Step-by-Step Process
-
-Start with the decision and ask "why was this approach chosen?" repeatedly:
-
-1. **Why this approach?** (Surface rationale)
-2. **Why does that matter?** (Underlying concern)
-3. **Why is that the constraint?** (Real constraint vs. assumed)
-4. **Why can't that constraint be changed?** (Fixed vs. movable)
-5. **Why is this the best way to address that root concern?** (Alternatives)
-
-### Example: "We chose a microservices architecture"
-
-| Level | Question | Answer |
-|-------|----------|--------|
-| Why 1 | "Why microservices?" | "We need independent deployability." |
-| Why 2 | "Why do you need independent deployability?" | "Different features have different release cadences." |
-| Why 3 | "Why do features have different release cadences?" | "The payments team ships weekly, the search team ships daily." |
-| Why 4 | "Why can't they ship on the same cadence?" | "Payments requires compliance review before each release." |
-| Why 5 | "Is there a simpler way to gate payments releases without splitting the entire architecture?" | "...actually, a feature flag + approval gate on the CI pipeline might work." |
-
-### Example: "We're using Redis for caching"
-
-| Level | Question | Answer |
-|-------|----------|--------|
-| Why 1 | "Why Redis?" | "We need caching for performance." |
-| Why 2 | "Why is performance a problem?" | "The dashboard loads slowly." |
-| Why 3 | "Why does the dashboard load slowly?" | "It makes 12 API calls on mount." |
-| Why 4 | "Why 12 API calls?" | "Each widget fetches its own data independently." |
-| Why 5 | "Could a single aggregated endpoint eliminate the need for caching?" | "...that would solve the latency without adding infrastructure." |
-
-### Example Questions for General Use
-
-- "Why was this library/framework/tool chosen over alternatives?"
-- "Why is this a hard requirement vs. a preference?"
-- "Why can't the upstream system provide this data in the format we need?"
-- "Why is this our responsibility rather than the caller's?"
-- "Why do we need this abstraction layer?"
-
-### Key Insight
-
-Reverse Five Whys frequently reveals that a complex solution is addressing a symptom rather than the root problem. The fifth "why" often points to a simpler intervention at a different level.
-
----
-
-## Framework Selection Guide
-
-| Situation | Primary Framework | Supporting Framework |
-|-----------|------------------|---------------------|
-| Reviewing a plan before execution | Pre-Mortem | Inversion |
-| Evaluating a specific technical decision | Five Whys (Reverse) | Steel-Manning |
-| Comprehensive design review | Six Thinking Hats | Socratic (all types) |
-| "This feels wrong but I can't say why" | Inversion | Pre-Mortem |
-| Challenging a confident proposal | Steel-Manning first | Then Socratic Assumptions |
-| Exploring whether we're solving the right problem | Socratic Meta-Questions | Five Whys (Reverse) |
-| Assessing operational readiness | Pre-Mortem | Inversion |
-| Reviewing someone else's code/PR | Steel-Manning first | Socratic Clarification |
-
----
-
-## Combining Frameworks: Recommended Sequence
-
-For a thorough review of any significant decision:
-
-1. **Steel-Man** — Understand why this approach is reasonable
-2. **Socratic Clarification** — Ensure the decision is well-defined
-3. **Five Whys (Reverse)** — Trace to root motivation
-4. **Inversion** — Enumerate failure conditions
-5. **Pre-Mortem** — Narrate specific failure scenarios
-6. **Socratic Implications** — Follow consequences forward
-
-This sequence moves from understanding to challenging — it builds credibility before critique, which makes the critique more effective and more likely to surface real issues rather than stylistic preferences.
+| Situation | Reach for |
+| --- | --- |
+| Reviewing a plan before execution | Pre-mortem, then inversion |
+| Evaluating one technical decision | Reverse five whys, then steel-man |
+| "This feels wrong but I can't say why" | Inversion, then pre-mortem |
+| Challenging a confident proposal | Steel-man first, then assumptions |
+| Reviewing someone else's code | Steel-man first, then clarification |

--- a/home/lib/ai/skills/maintaining-project-context/SKILL.md
+++ b/home/lib/ai/skills/maintaining-project-context/SKILL.md
@@ -6,177 +6,41 @@ user-invocable: false
 
 # Maintaining Project Context
 
-**REQUIRED SUB-SKILL:** Use writing-claude-md-files for all context file creation and updates.
+**REQUIRED SUB-SKILL:** Use writing-claude-md-files for all context file creation and updates — it owns the section structure, the freshness date, and the length budget.
 
 ## Core Principle
 
-Context files (CLAUDE.md or AGENTS.md) document contracts and architectural intent. When code changes contracts, the documentation must update. Stale documentation is worse than no documentation.
+Context files document contracts and architectural intent. **Update them when contracts change, not when implementation changes.** A changed export, interface, invariant, dependency, or architectural decision needs documenting; a bug fix, a refactor with the same behaviour, or a new test does not. Stale documentation is worse than none.
 
-**Trigger:** End of development phase, branch completion, or any work that changed contracts, APIs, or domain structure.
+**Trigger:** end of a development phase or branch, or any work that changed contracts, APIs, or domain structure.
 
-## Format Detection (MANDATORY FIRST STEP)
-
-Before any updates, detect what format this repository uses:
+## Format Detection (do this first)
 
 ```bash
-# Check for AGENTS.md at root
-ls -la AGENTS.md 2>/dev/null
-
-# Check for CLAUDE.md at root
-ls -la CLAUDE.md 2>/dev/null
+ls -la AGENTS.md CLAUDE.md 2>/dev/null
 ```
 
-| Root AGENTS.md? | Format              | Action                                             |
-| --------------- | ------------------- | -------------------------------------------------- |
-| Yes             | AGENTS.md-canonical | Update AGENTS.md files, create companion CLAUDE.md |
-| No              | CLAUDE.md-canonical | Update CLAUDE.md files directly                    |
-
-**Key principle:** We use OUR format structure (Purpose, Contracts, Dependencies, Invariants, etc.) regardless of filename. AGENTS.md is just for cross-platform AI agent compatibility.
-
-### AGENTS.md-Canonical Repos
-
-When the repo uses AGENTS.md:
-
-1. **Read AGENTS.md first** before making any updates
-2. **Write content to AGENTS.md** using our standard structure
-3. **Create companion CLAUDE.md** next to each AGENTS.md with exactly this content:
+An `AGENTS.md` at the root means the repo is AGENTS.md-canonical: read the existing file before editing, write content to `AGENTS.md`, and give each one a companion `CLAUDE.md` alongside it containing exactly:
 
 ```markdown
 Read @./AGENTS.md and treat its contents as if they were in CLAUDE.md
 ```
 
-## When to Update Context Files
-
-| Change Type                  | Update Required? | What to Update             |
-| ---------------------------- | ---------------- | -------------------------- |
-| New domain/module            | Yes              | Create domain context file |
-| API/interface change         | Yes              | Contracts section          |
-| Architectural decision       | Yes              | Key Decisions section      |
-| Invariant change             | Yes              | Invariants section         |
-| Dependency change            | Yes              | Dependencies section       |
-| Bug fix (no contract change) | No               | -                          |
-| Refactor (same behavior)     | No               | -                          |
-| Test additions               | No               | -                          |
+Otherwise the repo is CLAUDE.md-canonical — edit `CLAUDE.md` files directly. Either way the content uses our structure (Purpose, Contracts, Dependencies, Invariants, …); the filename is only about cross-platform agent compatibility.
 
 ## The Process
 
-### Step 1: Identify What Changed
-
-Diff against the base (branch start or phase start):
+Diff against the base — the branch point or the start of the phase:
 
 ```bash
-# Get changed files
 git diff --name-only <base-sha> HEAD
-
-# Get detailed changes
 git diff <base-sha> HEAD --stat
 ```
 
-Categorize changes:
+Sort the changes into structural (new or moved directories), contract (changed exports, interfaces, public APIs), behavioural (changed invariants or guarantees), and internal. Only the first three warrant an update.
 
-- **Structural:** New directories, moved files
-- **Contract:** Changed exports, interfaces, public APIs
-- **Behavioral:** Changed invariants, guarantees
-- **Internal:** Implementation details only
+Then, for each one that does:
 
-### Step 2: Map Changes to Context Files
-
-For each significant change, determine which context file should document it:
-
-| Change Location          | Context File Location             |
-| ------------------------ | --------------------------------- |
-| Project-wide pattern     | Root context file                 |
-| New domain               | `<domain>/` context file (create) |
-| Existing domain contract | `<domain>/` context file (update) |
-| Cross-domain dependency  | Both affected domains             |
-
-**Hierarchy rule:** Information belongs at the lowest level where it applies. Domain-specific contracts go in domain files, not root.
-
-**For AGENTS.md-canonical repos:** When creating new domain context files, create both `AGENTS.md` (with content) and `CLAUDE.md` (companion pointer).
-
-### Step 3: Verify Contracts Still Hold
-
-For each affected context file, verify:
-
-1. **Contracts section:** Do exposes/guarantees/expects match current code?
-2. **Dependencies section:** Are uses/used-by/boundary accurate?
-3. **Invariants section:** Are all invariants still enforced?
-4. **Key Decisions section:** Any new decisions to document?
-
-### Step 4: Update or Create Context Files
-
-**For updates:**
-
-1. Read existing file first (especially for AGENTS.md)
-2. Update freshness date via `date +%Y-%m-%d`
-3. Update affected sections
-4. Remove stale content
-5. Verify under token budget (<100 lines for domain files)
-
-**For new domains (CLAUDE.md-canonical repos):**
-
-1. Create `<domain>/CLAUDE.md` using template from writing-claude-md-files
-2. Document purpose, contracts, dependencies, invariants
-3. Set freshness date
-
-**For new domains (AGENTS.md-canonical repos):**
-
-1. Create `<domain>/AGENTS.md` using template from writing-claude-md-files
-2. Document purpose, contracts, dependencies, invariants
-3. Set freshness date
-4. Create companion `<domain>/CLAUDE.md`:
-   ```markdown
-   Read @./AGENTS.md and treat its contents as if they were in CLAUDE.md
-   ```
-
-## Decision Tree
-
-```
-Has code changed?
-├─ No → Skip (nothing to update)
-└─ Yes → Detect format first (AGENTS.md at root?)
-    │
-    └─ What changed?
-        ├─ Only tests/internal details → Skip
-        └─ Contracts/APIs/structure → Continue
-            │
-            ├─ New domain created?
-            │   ├─ AGENTS.md repo → Create AGENTS.md + companion CLAUDE.md
-            │   └─ CLAUDE.md repo → Create CLAUDE.md
-            │
-            ├─ Existing domain changed?
-            │   └─ Update domain context file (read first!)
-            │
-            └─ Project-wide pattern changed?
-                └─ Update root context file
-```
-
-## Quick Reference
-
-**Always update when:**
-
-- New public exports added
-- Interface signatures changed
-- Invariants added/removed
-- Dependencies changed
-- Architectural decisions made
-
-**Never update for:**
-
-- Internal refactoring
-- Bug fixes that don't change contracts
-- Test file changes
-- Comment/documentation-only changes
-
-## Common Mistakes
-
-| Mistake                           | Fix                                           |
-| --------------------------------- | --------------------------------------------- |
-| Updating for every change         | Only update for contract changes              |
-| Forgetting freshness date         | Always use `date +%Y-%m-%d`                   |
-| Documenting implementation        | Document contracts and intent                 |
-| Putting domain info in root       | Use domain context files for domain contracts |
-| Skipping verification             | Read the code, confirm contracts hold         |
-| Skipping format detection         | Always check for AGENTS.md first              |
-| Writing AGENTS.md without reading | Always read existing content before updating  |
-| Forgetting companion CLAUDE.md    | AGENTS.md repos need both files               |
+1. **Place it at the lowest level where it applies.** Domain-specific contracts belong in that domain's context file, not the root; project-wide patterns belong at the root; a cross-domain dependency touches both.
+2. **Read the existing file before editing it**, and verify against the code rather than the diff — do the documented contracts, dependencies, and invariants still hold?
+3. **Remove what went stale**, don't only append.

--- a/home/lib/ai/skills/writing-claude-md-files/SKILL.md
+++ b/home/lib/ai/skills/writing-claude-md-files/SKILL.md
@@ -12,35 +12,14 @@ cc:user-invocable: false
 
 CLAUDE.md files bridge Claude's statelessness. They preserve context so humans don't re-explain architectural intent every session.
 
-**Key distinction:**
+The whole hierarchy turns on one distinction:
 
-- **Top-level**: HOW to work in this codebase (commands, conventions)
-- **Subdirectory**: WHY this piece exists and what it PROMISES (contracts, intent)
+- **Top-level** — HOW to work in this codebase: commands, conventions, structure. "How to work here."
+- **Subdirectory** — WHY this piece exists and what it PROMISES: contracts, decisions, invariants. "Why this exists and what it promises."
 
-## File Hierarchy
-
-Claude automatically reads CLAUDE.md files from current directory up to root:
-
-```
-project/
-├── CLAUDE.md                    # Project-wide: tech stack, commands, conventions
-└── src/
-    └── domains/
-        ├── auth/
-        │   ├── CLAUDE.md        # Auth domain: purpose, contracts, invariants
-        │   └── oauth2/
-        │       └── CLAUDE.md    # OAuth2 subdomain (rare, only when needed)
-        └── billing/
-            └── CLAUDE.md        # Billing domain: purpose, contracts, invariants
-```
-
-**Depth guideline:** Typically one level (domain). Occasionally two (subdomain like `auth/oauth2`). Rarely more.
+Claude reads these from the current directory up to the root, so a subdirectory file inherits its parents and should never repeat them. Depth is typically one level (domain), occasionally two (a subdomain like `auth/oauth2`), rarely more.
 
 ## Top-Level CLAUDE.md
-
-Focuses on project-wide WHAT and HOW.
-
-### What to Include
 
 | Section           | Purpose                               |
 | ----------------- | ------------------------------------- |
@@ -50,56 +29,11 @@ Focuses on project-wide WHAT and HOW.
 | Conventions       | Naming, patterns used project-wide    |
 | Boundaries        | What Claude can/cannot edit           |
 
-### Template
-
-```markdown
-# [Project Name]
-
-Last verified: [DATE - use `date +%Y-%m-%d`]
-
-## Tech Stack
-
-- Language: TypeScript 5.x
-- Framework: Next.js 14
-- Database: PostgreSQL
-- Testing: Vitest
-
-## Commands
-
-- `npm run dev` - Start dev server
-- `npm run test` - Run tests
-- `npm run build` - Production build
-
-## Project Structure
-
-- `src/domains/` - Domain modules (auth, billing, etc.)
-- `src/shared/` - Cross-cutting utilities
-- `src/infrastructure/` - External adapters (DB, APIs)
-
-## Conventions
-
-- Functional Core / Imperative Shell pattern
-- Domain modules are self-contained
-- See domain CLAUDE.md files for domain-specific guidance
-
-## Boundaries
-
-- Safe to edit: `src/`
-- Never touch: `migrations/` (immutable), `*.lock` files
-```
-
-### What NOT to Include
-
-- Code style rules (use linters)
-- Exhaustive command lists (reference package.json)
-- Content that belongs in domain-level files
-- Sensitive information (keys, credentials)
+Leave out code style rules (that's what linters are for), exhaustive command lists (reference `package.json` or the justfile), anything that belongs in a domain file, and secrets.
 
 ## Subdirectory CLAUDE.md (Domain-Level)
 
-Focuses on WHY and CONTRACTS. The code shows WHAT; these files explain intent.
-
-### What to Include
+The code already shows WHAT. These files explain intent.
 
 | Section       | Purpose                                   |
 | ------------- | ----------------------------------------- |
@@ -108,51 +42,12 @@ Focuses on WHY and CONTRACTS. The code shows WHAT; these files explain intent.
 | Dependencies  | What it uses, what uses it, boundaries    |
 | Key Decisions | ADR-lite: decisions and rationale         |
 | Invariants    | Things that must ALWAYS be true           |
+| Key Files     | Entry points worth knowing about          |
 | Gotchas       | Non-obvious traps                         |
 
-### Template
+A domain file earns its place when the domain has non-obvious contracts with other parts, when architectural decisions constrain how the code should evolve, when invariants exist that the code doesn't make obvious, or when new sessions keep needing the same context re-explained. Skip it for trivial utility folders, for implementation details that churn, and for anything better said in a code comment.
 
-```markdown
-# [Domain Name]
-
-Last verified: [DATE - use `date +%Y-%m-%d`]
-
-## Purpose
-
-[1-2 sentences: WHY this domain exists, what problem it solves]
-
-## Contracts
-
-- **Exposes**: [public interfaces - what callers can use]
-- **Guarantees**: [promises this domain keeps]
-- **Expects**: [what callers must provide]
-
-## Dependencies
-
-- **Uses**: [domains/services this depends on]
-- **Used by**: [what depends on this domain]
-- **Boundary**: [what should NOT be imported here]
-
-## Key Decisions
-
-- [Decision]: [Rationale]
-
-## Invariants
-
-- [Thing that must always be true]
-
-## Key Files
-
-- `index.ts` - Public exports
-- `types.ts` - Domain types
-- `service.ts` - Main service implementation
-
-## Gotchas
-
-- [Non-obvious thing that will bite you]
-```
-
-### Example: Auth Domain
+### Example
 
 ```markdown
 # Auth Domain
@@ -161,8 +56,8 @@ Last verified: 2025-12-17
 
 ## Purpose
 
-Ensures user identity is verified exactly once at the system edge.
-All downstream services trust the auth token without re-validating.
+Verifies user identity exactly once at the system edge; downstream
+services trust the token without re-validating.
 
 ## Contracts
 
@@ -173,129 +68,41 @@ All downstream services trust the auth token without re-validating.
 ## Dependencies
 
 - **Uses**: Database (users table), Redis (session cache)
-- **Used by**: All API routes, billing domain (user identity only)
-- **Boundary**: Do NOT import from billing, notifications, or other domains
+- **Used by**: All API routes, billing (user identity only)
+- **Boundary**: Do NOT import from billing or notifications
 
 ## Key Decisions
 
-- JWT over session cookies: Stateless auth for horizontal scaling
-- bcrypt cost 12: Legacy decision, migration to argon2 tracked in ADR-007
+- JWT over session cookies: stateless auth for horizontal scaling
 
 ## Invariants
 
-- Every user has exactly one primary email
-- Deleted users are soft-deleted (is_deleted), never hard deleted
-- User IDs are UUIDs, never sequential
-
-## Key Files
-
-- `service.ts` - AuthService implementation
-- `tokens.ts` - JWT creation/validation
-- `types.ts` - User, Token, Session types
+- Deleted users are soft-deleted (`is_deleted`), never hard deleted
 
 ## Gotchas
 
-- Token validation returns null on invalid (doesn't throw)
-- Never return raw password hashes in User objects
+- Token validation returns null on invalid — it doesn't throw
 ```
+
+Note what the Purpose section does *not* say: "handles authentication." That is recoverable from the directory name. "Verified exactly once at the edge, downstream trusts the token" is not.
 
 ## Freshness Dates: MANDATORY
 
-Every CLAUDE.md MUST include a "Last verified" date.
+Every CLAUDE.md MUST carry a `Last verified:` date, because a stale one is worse than none — the date is what tells a reader when the contracts were last confirmed.
 
-**CRITICAL:** Use Bash to get the actual date. Do NOT hallucinate dates.
+**Get the real date from Bash. Do NOT write one from memory:**
 
 ```bash
 date +%Y-%m-%d
 ```
 
-Include in file:
-
-```markdown
-Last verified: 2025-12-17
-```
-
-**Why mandatory:** Stale CLAUDE.md files are worse than none. The date signals when contracts were last confirmed accurate.
-
 ## Referencing Files
 
-You can reference key files in CLAUDE.md:
+Name key files plainly (`service.ts - main implementation`). **Do NOT use `@` syntax** (`@./service.ts`) — it force-loads the file into context on every read of the CLAUDE.md, burning tokens whether or not anyone needed it.
 
-```markdown
-## Key Files
+## Updating
 
-- `index.ts` - Public exports
-- `service.ts` - Main implementation
-```
-
-**Do NOT use @ syntax** (e.g., `@./service.ts`). This force-loads files into context, burning tokens. Just name the files; Claude can read them when needed.
-
-## Heuristics: Top-Level vs Subdirectory
-
-| Question                         | Top-level | Subdirectory |
-| -------------------------------- | --------- | ------------ |
-| Applies project-wide?            | ✓         |              |
-| New engineer needs on day 1?     | ✓         |              |
-| About commands/conventions?      | ✓         |              |
-| About WHY a component exists?    |           | ✓            |
-| About contracts between parts?   |           | ✓            |
-| Changes when the domain changes? |           | ✓            |
-
-**Rule of thumb:**
-
-- Top-level = "How to work here"
-- Subdirectory = "Why this exists and what it promises"
-
-## When to Create Subdirectory CLAUDE.md
-
-Create when:
-
-- Domain has non-obvious contracts with other parts
-- Architectural decisions affect how code should evolve
-- Invariants exist that aren't obvious from code
-- New sessions consistently need the same context re-explained
-
-Don't create for:
-
-- Trivial utility folders
-- Implementation details that change frequently
-- Content better captured in code comments
-
-## Updating CLAUDE.md Files
-
-When updating any CLAUDE.md:
-
-1. **Update the freshness date** using Bash `date +%Y-%m-%d`
-2. **Verify contracts still hold** - read the code, check invariants
-3. **Remove stale content** - better short and accurate than long and wrong
-4. **Keep token-efficient** - <300 lines top-level, <100 lines subdirectory
-
-## Common Mistakes
-
-| Mistake                    | Fix                                           |
-| -------------------------- | --------------------------------------------- |
-| Describing WHAT code does  | Focus on WHY it exists, contracts it keeps    |
-| Missing freshness date     | Always include, always use Bash for real date |
-| Using @ to reference files | Just name files, let Claude read on demand    |
-| Too much detail            | Subdirectory files should be <100 lines       |
-| Duplicating parent content | Subdirectory inherits parent; don't repeat    |
-| Stale contracts            | Update when domain changes; verify dates      |
-
-## Checklist
-
-**Top-level:**
-
-- [ ] Tech stack listed
-- [ ] Key commands documented
-- [ ] Project structure overview
-- [ ] Freshness date (from `date +%Y-%m-%d`)
-
-**Subdirectory:**
-
-- [ ] Purpose explains WHY (not what)
-- [ ] Contracts: exposes, guarantees, expects
-- [ ] Dependencies and boundaries clear
-- [ ] Key decisions with rationale
-- [ ] Invariants documented
-- [ ] Freshness date (from `date +%Y-%m-%d`)
-- [ ] Under 100 lines
+1. Update the freshness date from `date +%Y-%m-%d`
+2. Verify the contracts still hold — read the code, don't trust the diff
+3. Remove stale content; short and accurate beats long and wrong
+4. Stay within budget: <300 lines top-level, <100 lines subdirectory

--- a/home/lib/ai/skills/writing-plans/SKILL.md
+++ b/home/lib/ai/skills/writing-plans/SKILL.md
@@ -11,8 +11,6 @@ Write comprehensive implementation plans assuming the engineer has zero context 
 
 Assume they are a skilled developer, but know almost nothing about our toolset or problem domain. Assume they don't know good test design very well.
 
-**Announce at start:** "I'm using the writing-plans skill to create the implementation plan."
-
 **Inputs:** a spec (typically at `docs/specs/YYYY-MM-DD-<topic>.md`) plus any constraints raised during brainstorming.
 
 ## Output Mode
@@ -233,11 +231,3 @@ After the plan is written (markdown mode) or the beans tree is created (beans mo
 3. **Type consistency** — do the types, method signatures, and property names you used in later tasks match what you defined in earlier tasks? A function called `clearLayers()` in task 3 but `clearFullLayers()` in task 7 is a bug.
 
 If you find issues, fix them inline. No need to re-review your own fixes — just fix and move on.
-
-## Remember
-
-- Exact file paths always
-- Complete code in every step — if a step changes code, show the code
-- Exact commands with expected output
-- DRY, YAGNI, TDD, frequent commits
-- The bean body (or plan section) must stand alone — assume the reader picks it up cold


### PR DESCRIPTION
Closes out `dotfiles-nj63` with its last four child beans. `home/lib/ai/` markdown goes from 2,891 to 1,803 lines (~38%), with the calibration and mechanism deliberately left intact.

| Bean | File | Before → After |
| --- | --- | --- |
| `dotfiles-o58n` | brainstorming / writing-plans | 127→118, 243→233 |
| `dotfiles-m7np` | maintaining-project-context | 182→46 |
| `dotfiles-p4l3` | writing-claude-md-files | 301→108 |
| `dotfiles-e6kx` | questioning-frameworks / blind-spots | 405→97, 337→48 |

- **brainstorming / writing-plans** — cut the Key Principles restatement, the "announce at start" ritual, and the Remember section. HARD-GATE, plannotator commands, and beans invocations stay: guardrail and mechanism, not ceremony. `diff-scope` untouched.
- **maintaining-project-context** — five renderings of "update when contracts change, not when implementation changes" collapsed to one. Format detection, the companion-pointer convention, and the diff commands survive; templates and freshness dates defer to the declared sub-skill.
- **writing-claude-md-files** — two templates, a heuristics table, a Common Mistakes table, and a Checklist all restated the section lists. The example stays synthetic rather than pointing at repo files, since this skill deploys to `~/.claude/skills/` on every machine and runs in arbitrary projects.
- **devils-advocate** — the two generic references keep every framework and all 11 blind-spot categories, losing only the exposition. `SKILL.md` calibration and `ai-blind-spots.md` are untouched; one stale pointer to a now-folded section was fixed.

Follow-ups: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)