### PR TITLE
beans: plan the paseo home-manager module

### DIFF
--- a/.beans/dotfiles-7043--paseo-home-manager-module.md
+++ b/.beans/dotfiles-7043--paseo-home-manager-module.md
@@ -1,0 +1,34 @@
+---
+# dotfiles-7043
+title: paseo home-manager module
+status: todo
+type: epic
+priority: normal
+created_at: 2026-08-19T10:54:25Z
+updated_at: 2026-08-19T11:00:24Z
+---
+
+**Goal:** Expose paseo as `pkgs.dotfiles.paseo` plus a `dotfiles.programs.paseo` home-manager module that runs the daemon as a user service on both Linux (systemd user unit) and macOS (launchd agent).
+
+**Architecture:** A flake input pinned to `v0.3.1` feeds `overlays/paseo.nix`, which `callPackage`s upstream's `nix/package.nix` with our own `npmDepsHash` and a `node-pty` prebuilds fix, landing the result at `pkgs.dotfiles.paseo`. `home/programs/paseo.nix` follows the repo's program-module pattern and drives both launchers through one shared `writeShellScript` launcher — the only way `passwordFile` can behave identically on macOS (launchd has no `EnvironmentFile`). A `paseo-module` flake check evaluates a scratch home-manager config with a stub package and greps the rendered unit/agent.
+
+**Tech Stack:** Nix flakes, nixpkgs 26.05, home-manager (release-26.05), buildNpmPackage.
+
+**Spec:** docs/specs/2026-08-19-paseo-home-manager-module.md
+
+## Notes
+
+- `sys-warbird` is explicitly **not** migrated here. That is deferred follow-up work.
+- Relay is hardcoded off (`--no-relay`, no options). No `settings`/`config.json` rendering.
+- One refinement over the spec: the `paseo-module` check is defined for **both** systems, not Linux-only. CI still only builds the `x86_64-linux` one, but a darwin definition lets the implementer verify the launchd path locally. Verified working during planning.
+
+## Relationship to the home-eval harness (dotfiles-6f5q)
+
+A separate epic plans a `home-eval` check (`checks/home-eval.nix` + `mkHomeEvalCheck`, bean dotfiles-d6t2) that evaluates a home-manager config and forces `config.assertions` for the AI-assistant modules.
+
+That is **complementary**, not a duplicate, and the two are expected to coexist in `checks`:
+
+- `home-eval` — broad, eval-only, forces assertions across many modules. Answers "does `home/` still evaluate".
+- `paseo-module` — narrow, builds a tiny derivation, greps the *rendered* unit and launcher. Answers "does the module actually emit the wiring it promises".
+
+Neither blocks the other. Whichever lands second simply sits beside the first in the `checks` attribute. If `home-eval` is already present when this epic starts, add `mkPaseoModuleCheck` next to `mkHomeEvalCheck` and follow whatever placement convention that work established.

--- a/.beans/dotfiles-c6r0--add-password-and-passwordfile-options-to-the-paseo.md
+++ b/.beans/dotfiles-c6r0--add-password-and-passwordfile-options-to-the-paseo.md
@@ -1,0 +1,163 @@
+---
+# dotfiles-c6r0
+title: Add password and passwordFile options to the paseo module
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-19T10:57:58Z
+updated_at: 2026-08-19T10:59:18Z
+parent: dotfiles-ltuq
+blocked_by:
+    - dotfiles-oelc
+---
+
+**Files:**
+- Modify: `home/programs/paseo.nix` — options block, `launcher`, `serviceEnv`, `assertions`
+- Modify: `flake.nix` — the scratch config inside `mkPaseoModuleCheck`
+
+Background: paseo reads `PASEO_PASSWORD` as **plaintext** and bcrypt-hashes it at startup (`packages/server/src/server/config.ts:409` upstream). There is no hashed-input variable, so a declarative password either lands in the world-readable Nix store (`password`) or is read from a file outside it at process start (`passwordFile`).
+
+`passwordFile` is read inside the shared launcher rather than via systemd's `EnvironmentFile=`, because launchd has no file-based equivalent — the launcher is the only mechanism that behaves identically on both platforms.
+
+- [ ] **Step 1: Extend the check's scratch config**
+
+In `flake.nix`, inside `mkPaseoModuleCheck`'s `dotfiles.programs.paseo` block, add:
+
+```nix
+                passwordFile = "/run/secrets/paseo-password";
+```
+
+and add these lines to the `runCommandLocal` script, before `touch $out`:
+
+```bash
+          grep -F '/run/secrets/paseo-password' ${launcher}
+          # The secret must be read at start, never baked into the unit.
+          ! grep -F 'PASEO_PASSWORD' ${unit}
+```
+
+- [ ] **Step 2: Run the check to verify it fails**
+
+Run: `nix build .#checks.aarch64-darwin.paseo-module --no-link 2>&1 | tail -5`
+Expected: FAIL with `The option 'dotfiles.programs.paseo.passwordFile' does not exist`.
+
+- [ ] **Step 3: Add the options**
+
+In `home/programs/paseo.nix`, add to `options.dotfiles.programs.paseo` after `allowAnyHostname`:
+
+```nix
+    password = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Daemon password, in plaintext. Paseo hashes it at startup; there is no
+        hashed-input variable to use instead.
+
+        This value is written into the Nix store, which is world-readable on the
+        host, and into whatever config declares it. Prefer `passwordFile`.
+      '';
+    };
+
+    passwordFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/paseo-password";
+      description = ''
+        Path to a file outside the Nix store containing the plaintext daemon
+        password and nothing else.
+
+        Read by the launcher at each service start, so rotating the secret needs
+        only a service restart, not a home-manager switch. An unreadable file is
+        a startup failure rather than a silently unauthenticated daemon.
+      '';
+    };
+```
+
+- [ ] **Step 4: Thread them through**
+
+In `launcher`, insert the read between the `chmod` and the `exec` — **not** after the `exec`, which would never run. The launcher body reads, in full:
+
+```nix
+  launcher = pkgs.writeShellScript "paseo-launcher" ''
+    set -euo pipefail
+
+    export PATH="${servicePath}"
+
+    # home-manager has no systemd.tmpfiles equivalent; upstream's NixOS module
+    # creates PASEO_HOME with the same 0700 mode.
+    mkdir -p "$PASEO_HOME"
+    chmod 700 "$PASEO_HOME"
+    ${lib.optionalString (cfg.passwordFile != null) ''
+      # Read at start, not at switch. `set -e` above turns an unreadable file
+      # into a loud failure rather than a silently unauthenticated daemon.
+      PASEO_PASSWORD="$(cat ${cfg.passwordFile})"
+      export PASEO_PASSWORD
+    ''}
+    exec ${cfg.package}/bin/paseo-server --no-relay
+  '';
+```
+
+In `serviceEnv`, add the plain-password case **before** the `cfg.environment` merge:
+
+```nix
+  // lib.optionalAttrs (cfg.password != null) { PASEO_PASSWORD = cfg.password; }
+  // cfg.environment;
+```
+
+Add a second entry to `assertions`:
+
+```nix
+      {
+        assertion = !(cfg.password != null && cfg.passwordFile != null);
+        message = ''
+          dotfiles.programs.paseo: password and passwordFile are mutually
+          exclusive -- set one or the other.
+        '';
+      }
+```
+
+- [ ] **Step 5: Run the check to verify it passes**
+
+Run: `nix build .#checks.aarch64-darwin.paseo-module --no-link`
+Expected: PASS (no output, exit 0).
+
+- [ ] **Step 6: Verify the assertion fires**
+
+```bash
+nix eval --impure --expr '
+let f = builtins.getFlake (toString ./.);
+in (f.lib.mkHomeManagerSystem {
+  system = "aarch64-darwin";
+  user = "t";
+  directory = "/Users/t";
+  home = {
+    home.stateVersion = "23.05";
+    dotfiles.profiles.base = false;
+    dotfiles.programs.paseo = {
+      enable = true;
+      password = "hunter2";
+      passwordFile = "/run/secrets/paseo-password";
+    };
+  };
+}).config.home.activationPackage' 2>&1 | tail -5
+```
+
+Expected: FAIL with `mutually exclusive` in the message.
+
+- [ ] **Step 7: Run the whole check suite**
+
+Run: `nix flake check --print-build-logs`
+Expected: PASS. Note this builds `pkgs.dotfiles.paseo` for real (a full npm + node-gyp build), so allow several minutes on a cold store.
+
+- [ ] **Step 8: Format check**
+
+Run: `nixfmt --check flake.nix home/programs/paseo.nix`
+Expected: no output, exit 0.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add flake.nix home/programs/paseo.nix
+git commit -m "home/programs/paseo: add password and passwordFile options
+
+Bean: dotfiles-c6r0"
+```

--- a/.beans/dotfiles-l710--add-the-paseo-flake-input-pinned-to-v031.md
+++ b/.beans/dotfiles-l710--add-the-paseo-flake-input-pinned-to-v031.md
@@ -1,0 +1,59 @@
+---
+# dotfiles-l710
+title: Add the paseo flake input pinned to v0.3.1
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-19T10:54:52Z
+updated_at: 2026-08-19T10:54:58Z
+parent: dotfiles-pg0j
+---
+
+**Files:**
+- Modify: `flake.nix` (the `inputs` block, after the `crane` entry)
+- Modify: `flake.lock` (generated)
+
+Context: paseo's own flake pins `nixpkgs-unstable`. We follow our `nixpkgs` so the package is built against this repo's pin — that is what makes the `npmDepsHash` ours to own rather than upstream's to break. Pinned to `v0.3.1` deliberately (not `v0.4.0`).
+
+Work from inside the devShell (`direnv` shell) so `nixfmt` is on `PATH` for the pre-commit hook.
+
+- [ ] **Step 1: Add the input**
+
+In `flake.nix`, inside `inputs`, after the `crane.url` line:
+
+```nix
+    # Self-hosted orchestrator for AI coding agents. Pinned to a tag: paseo's
+    # release tags ship a stale nix/npm-deps.hash, so overlays/paseo.nix has to
+    # supply a matching hash for whatever tag is pinned here. Bump both together.
+    paseo = {
+      url = "github:getpaseo/paseo/v0.3.1";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+```
+
+- [ ] **Step 2: Lock the input**
+
+Run: `nix flake lock`
+Expected: `warning: updating lock file ...` plus a line adding `paseo`. `flake.lock` is modified.
+
+- [ ] **Step 3: Verify the input resolves and the flake still evaluates**
+
+Run: `nix flake metadata --json | jq -r '.locks.nodes.paseo.locked.rev'`
+Expected: a 40-character commit sha (the v0.3.1 tag's commit), not an error.
+
+Run: `nix eval .#lib --apply builtins.attrNames`
+Expected: `[ "mkDarwin" "mkHomeManagerSystem" "mkNixosSystem" "mkShells" ]`
+
+- [ ] **Step 4: Format check**
+
+Run: `nixfmt --check flake.nix`
+Expected: no output, exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add flake.nix flake.lock
+git commit -m "flake: add paseo input pinned to v0.3.1
+
+Bean: dotfiles-l710"
+```

--- a/.beans/dotfiles-lpk0--add-the-paseo-module-skeleton-and-its-flake-eval-c.md
+++ b/.beans/dotfiles-lpk0--add-the-paseo-module-skeleton-and-its-flake-eval-c.md
@@ -1,0 +1,274 @@
+---
+# dotfiles-lpk0
+title: Add the paseo module skeleton and its flake eval check
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-19T10:56:39Z
+updated_at: 2026-08-19T11:00:24Z
+parent: dotfiles-ltuq
+blocked_by:
+    - dotfiles-rdkr
+---
+
+**Files:**
+- Create: `home/programs/paseo.nix` (auto-imported by `home/default.nix` — no registration needed)
+- Modify: `flake.nix` — add `mkPaseoModuleCheck` to the top-level `let`, and a `paseo-module` entry to both systems' `checks`
+
+Test-first: the check goes in before the module, fails because the option does not exist, then the module makes it pass.
+
+The check is deliberately cheap. It passes a **stub** `package` so grepping the rendered unit never drags in paseo's real npm build, which means it runs in seconds on both platforms. All attribute paths below were verified against the pinned home-manager (`4baa8ac`) during planning.
+
+- [ ] **Step 1: Write the failing check**
+
+In `flake.nix`, add to the top-level `let` block, after `mkNixfmtCheck`:
+
+```nix
+      # Evaluates a scratch home-manager config with the paseo module enabled and
+      # greps the rendered unit/agent for the wiring the module promises. The stub
+      # `package` keeps this an eval check: grepping the unit must not drag in
+      # paseo's npm build. Defined for both systems even though CI only builds the
+      # linux one -- it is what makes the launchd path verifiable on a Mac.
+      mkPaseoModuleCheck =
+        { pkgs, system }:
+        let
+          isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
+          hm = mkHomeManagerSystem {
+            inherit system;
+            user = "paseo-check";
+            directory = if isDarwin then "/Users/paseo-check" else "/home/paseo-check";
+            home = {
+              home.stateVersion = "23.05";
+              # Keeps the eval cheap -- none of the base programs are relevant here.
+              dotfiles.profiles.base = false;
+              dotfiles.programs.paseo = {
+                enable = true;
+                package = pkgs.writeShellScriptBin "paseo-server" "";
+                listenAddress = "0.0.0.0";
+                port = 7171;
+              };
+            };
+          };
+          # home-manager materialises user units through xdg.configFile; on darwin
+          # the agent plist is not exposed as a file, so serialise the evaluated
+          # config instead.
+          unit =
+            if isDarwin then
+              pkgs.writeText "paseo-agent.json" (
+                builtins.toJSON hm.config.launchd.agents.paseo.config
+              )
+            else
+              hm.config.xdg.configFile."systemd/user/paseo.service".source;
+          launcher =
+            if isDarwin then
+              builtins.head hm.config.launchd.agents.paseo.config.ProgramArguments
+            else
+              builtins.head hm.config.systemd.user.services.paseo.Service.ExecStart;
+        in
+        pkgs.runCommandLocal "paseo-module-check" { } ''
+          set -euo pipefail
+          grep -F '0.0.0.0:7171' ${unit}
+          grep -F -- '--no-relay' ${launcher}
+          grep -F '/.local/bin' ${launcher}
+          touch $out
+        '';
+```
+
+Then add it to both systems in the `checks` attribute:
+
+```nix
+          aarch64-darwin =
+            self.packages.aarch64-darwin
+            // darwinPkgs.dotfiles.internal.rustChecks
+            // {
+              nixfmt = mkNixfmtCheck darwinPkgs;
+              paseo-module = mkPaseoModuleCheck {
+                pkgs = darwinPkgs;
+                system = "aarch64-darwin";
+              };
+            };
+          x86_64-linux =
+            self.packages.x86_64-linux
+            // linuxPkgs.dotfiles.internal.rustChecks
+            // {
+              nixfmt = mkNixfmtCheck linuxPkgs;
+              paseo-module = mkPaseoModuleCheck {
+                pkgs = linuxPkgs;
+                system = "x86_64-linux";
+              };
+            };
+```
+
+- [ ] **Step 2: Run the check to verify it fails**
+
+Run: `nix build .#checks.aarch64-darwin.paseo-module --no-link 2>&1 | tail -5`
+Expected: FAIL with `The option 'dotfiles.programs.paseo' does not exist`.
+
+- [ ] **Step 3: Write the module**
+
+Create `home/programs/paseo.nix`:
+
+```nix
+# Paseo, a self-hosted daemon for AI coding agents, as a *user* service --
+# systemd user unit on Linux, launchd agent on macOS. Upstream ships a NixOS
+# system module only.
+#
+# Note for Linux hosts: a systemd user service is stopped at logout unless the
+# system config sets `users.users.<name>.linger = true`. home-manager cannot set
+# that; it is a downstream system-config requirement.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.dotfiles.programs.paseo;
+
+  systemPaths =
+    if pkgs.stdenv.isDarwin then
+      [
+        "/etc/profiles/per-user/${config.home.username}/bin"
+        "/run/current-system/sw/bin"
+        "/nix/var/nix/profiles/default/bin"
+        "/usr/bin"
+        "/bin"
+        "/usr/sbin"
+        "/sbin"
+      ]
+    else
+      [
+        "/etc/profiles/per-user/${config.home.username}/bin"
+        "/run/current-system/sw/bin"
+        "/run/wrappers/bin"
+        "/nix/var/nix/profiles/default/bin"
+      ];
+
+  # `~/.local/bin` is unconditional and first among the defaults: the claude-code
+  # and codex modules install their wrappers there via home.activation, and no Nix
+  # profile directory covers it. Agents the daemon spawns need them on PATH --
+  # this is the `mkForce` that downstream system configs would otherwise carry.
+  servicePath = lib.concatStringsSep ":" (
+    lib.unique (
+      [ "${config.home.homeDirectory}/.local/bin" ]
+      ++ config.home.sessionPath
+      ++ [ "${config.home.profileDirectory}/bin" ]
+      ++ systemPaths
+    )
+  );
+
+  launcher = pkgs.writeShellScript "paseo-launcher" ''
+    set -euo pipefail
+
+    export PATH="${servicePath}"
+
+    # home-manager has no systemd.tmpfiles equivalent; upstream's NixOS module
+    # creates PASEO_HOME with the same 0700 mode.
+    mkdir -p "$PASEO_HOME"
+    chmod 700 "$PASEO_HOME"
+
+    exec ${cfg.package}/bin/paseo-server --no-relay
+  '';
+
+  serviceEnv = {
+    PASEO_HOME = cfg.dataDir;
+    PASEO_LISTEN = "${cfg.listenAddress}:${toString cfg.port}";
+  };
+in
+{
+  options.dotfiles.programs.paseo = {
+    enable = lib.mkEnableOption "Enable the paseo daemon as a user service";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.dotfiles.paseo;
+      defaultText = lib.literalExpression "pkgs.dotfiles.paseo";
+      description = "The paseo package to run.";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.home.homeDirectory}/.paseo";
+      defaultText = lib.literalExpression ''"''${config.home.homeDirectory}/.paseo"'';
+      description = "Directory holding paseo's state, exported as PASEO_HOME.";
+    };
+
+    listenAddress = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      description = "Address the daemon binds to.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 6767;
+      description = "Port the daemon listens on.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # The CLI, so `paseo ...` works interactively and not just as a daemon.
+    home.packages = [ cfg.package ];
+
+    launchd.agents.paseo = lib.mkIf pkgs.stdenv.isDarwin {
+      enable = true;
+      config = {
+        ProgramArguments = [ "${launcher}" ];
+        KeepAlive = true;
+        RunAtLoad = true;
+        EnvironmentVariables = serviceEnv;
+        StandardOutPath = "${config.home.homeDirectory}/Library/Logs/paseo.log";
+        StandardErrorPath = "${config.home.homeDirectory}/Library/Logs/paseo.log";
+      };
+    };
+
+    systemd.user.services.paseo = lib.mkIf pkgs.stdenv.isLinux {
+      Unit = {
+        Description = "Paseo - self-hosted daemon for AI coding agents";
+        After = [ "network.target" ];
+      };
+      Service = {
+        ExecStart = "${launcher}";
+        # home-manager types this as `listOf str`, so the attrset is rendered
+        # here. systemd unquotes Environment= shell-style, hence escapeShellArg.
+        Environment = lib.mapAttrsToList (k: v: "${k}=${lib.escapeShellArg v}") serviceEnv;
+        Restart = "on-failure";
+        RestartSec = 5;
+        # Upstream's server handles SIGTERM with a 10s internal timeout.
+        KillSignal = "SIGTERM";
+        TimeoutStopSec = 15;
+      };
+      Install.WantedBy = [ "default.target" ];
+    };
+  };
+}
+```
+
+- [ ] **Step 4: Run the check on both systems to verify it passes**
+
+Run: `nix build .#checks.aarch64-darwin.paseo-module --no-link`
+Expected: PASS (no output, exit 0). This exercises the launchd path.
+
+Run: `nix eval --raw .#checks.x86_64-linux.paseo-module.drvPath`
+Expected: a `/nix/store/...paseo-module-check.drv` path. This proves the systemd path evaluates; building it needs a linux builder, and CI covers that.
+
+- [ ] **Step 5: Format check**
+
+Run: `nixfmt --check flake.nix home/programs/paseo.nix`
+Expected: no output, exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add flake.nix home/programs/paseo.nix
+git commit -m "home/programs/paseo: add module with systemd and launchd services
+
+Bean: dotfiles-lpk0"
+```
+
+## Note: a second eval check may already exist
+
+Bean dotfiles-d6t2 (separate epic) adds a `home-eval` check with `mkHomeEvalCheck` in the same `let` block and a `checks/home-eval.nix` module. If that has already landed when you pick this up:
+
+- Put `mkPaseoModuleCheck` beside `mkHomeEvalCheck`, not in place of it. They answer different questions — `home-eval` forces assertions broadly, this one greps the rendered unit for specific wiring.
+- Do not move this check's scratch config into `checks/home-eval.nix`. Enabling paseo there would pull `pkgs.dotfiles.paseo` into that check's closure, which is exactly what the stub `package` here avoids.

--- a/.beans/dotfiles-ltuq--paseo-home-manager-module.md
+++ b/.beans/dotfiles-ltuq--paseo-home-manager-module.md
@@ -1,0 +1,17 @@
+---
+# dotfiles-ltuq
+title: paseo home-manager module
+status: todo
+type: feature
+created_at: 2026-08-19T10:54:38Z
+updated_at: 2026-08-19T10:54:38Z
+parent: dotfiles-7043
+---
+
+The module itself: `home/programs/paseo.nix`, auto-imported by `home/default.nix`.
+
+Owns the whole option surface (`enable`, `package`, `dataDir`, `listenAddress`, `port`, `hostnames`, `allowAnyHostname`, `password`, `passwordFile`, `environment`, `extraPath`), the shared launcher script, and both service definitions (`systemd.user.services.paseo` on Linux, `launchd.agents.paseo` on macOS).
+
+Not wired into any profile in `home/profiles.nix` — opt-in per host.
+
+Tasks in this feature are TDD against the `paseo-module` flake check, which the first task introduces alongside the module skeleton. Each subsequent task extends the check's scratch config first, watches it fail, then implements.

--- a/.beans/dotfiles-oelc--add-hostnames-and-allowanyhostname-options-to-the.md
+++ b/.beans/dotfiles-oelc--add-hostnames-and-allowanyhostname-options-to-the.md
@@ -1,0 +1,153 @@
+---
+# dotfiles-oelc
+title: Add hostnames and allowAnyHostname options to the paseo module
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-19T10:57:32Z
+updated_at: 2026-08-19T10:57:37Z
+parent: dotfiles-ltuq
+blocked_by:
+    - dotfiles-p1pz
+---
+
+**Files:**
+- Modify: `home/programs/paseo.nix` — options block, `serviceEnv`, new `assertions`
+- Modify: `flake.nix` — the scratch config inside `mkPaseoModuleCheck`
+
+Background, because the semantics are surprising: paseo's allowlist matches the **`Host` header**, not the bind address (`packages/server/src/server/hostnames.ts` upstream). The built-in defaults allow `localhost`, `*.localhost`, and any literal IP. So with `listenAddress = "0.0.0.0"`, reaching the daemon at `http://192.168.1.5:6767` needs no config, but `http://warbird.lan:6767` is **rejected** — the websocket upgrade fails with `403 Host not allowed`, which usually presents as "the UI loads but never connects".
+
+Upstream also accepts `PASEO_HOSTNAMES=true` to disable the check. We expose that as a separate boolean rather than mirroring upstream's `either (enum [ true ]) (listOf str)` union.
+
+- [ ] **Step 1: Extend the check's scratch config**
+
+In `flake.nix`, inside `mkPaseoModuleCheck`'s `dotfiles.programs.paseo` block, add:
+
+```nix
+                hostnames = [ "warbird.lan" ];
+```
+
+and add this line to the `runCommandLocal` script, before `touch $out`:
+
+```bash
+          grep -F 'warbird.lan' ${unit}
+```
+
+- [ ] **Step 2: Run the check to verify it fails**
+
+Run: `nix build .#checks.aarch64-darwin.paseo-module --no-link 2>&1 | tail -5`
+Expected: FAIL with `The option 'dotfiles.programs.paseo.hostnames' does not exist`.
+
+- [ ] **Step 3: Add the options**
+
+In `home/programs/paseo.nix`, add to `options.dotfiles.programs.paseo` after `port`:
+
+```nix
+    hostnames = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "warbird.lan"
+        ".example.com"
+      ];
+      description = ''
+        Hostnames the daemon accepts in the Host header (DNS rebinding
+        protection). Matched against the Host header, NOT the bind address, so
+        `listenAddress` has no bearing on it.
+
+        Added to the built-in defaults, never a replacement for them: localhost,
+        *.localhost and any literal IP address are always allowed. Reaching the
+        daemon at http://192.168.1.5:6767 therefore needs nothing here, while
+        http://warbird.lan:6767 needs `[ "warbird.lan" ]`. A leading dot matches
+        a domain and all its subdomains.
+
+        A rejected host fails the websocket upgrade with 403 Host not allowed,
+        which typically looks like the UI loading but never connecting.
+      '';
+    };
+
+    allowAnyHostname = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Accept any Host header, disabling DNS rebinding protection entirely.
+        Any web page you visit can then reach the daemon by name. Prefer listing
+        the names you actually use in `hostnames`.
+      '';
+    };
+```
+
+- [ ] **Step 4: Thread them into the environment and add the assertion**
+
+In `serviceEnv`, insert both `optionalAttrs` blocks **before** the `cfg.environment` merge, so the escape hatch still wins:
+
+```nix
+  serviceEnv = {
+    PASEO_HOME = cfg.dataDir;
+    PASEO_LISTEN = "${cfg.listenAddress}:${toString cfg.port}";
+  }
+  // lib.optionalAttrs cfg.allowAnyHostname { PASEO_HOSTNAMES = "true"; }
+  // lib.optionalAttrs (cfg.hostnames != [ ]) {
+    PASEO_HOSTNAMES = lib.concatStringsSep "," cfg.hostnames;
+  }
+  // cfg.environment;
+```
+
+In `config`, add an `assertions` attribute (first entry in the block):
+
+```nix
+    assertions = [
+      {
+        assertion = !(cfg.allowAnyHostname && cfg.hostnames != [ ]);
+        message = ''
+          dotfiles.programs.paseo: allowAnyHostname and hostnames are mutually
+          exclusive -- allowAnyHostname accepts every Host header, which makes
+          the hostnames list dead config.
+        '';
+      }
+    ];
+```
+
+- [ ] **Step 5: Run the check to verify it passes**
+
+Run: `nix build .#checks.aarch64-darwin.paseo-module --no-link`
+Expected: PASS (no output, exit 0).
+
+- [ ] **Step 6: Verify the assertion actually fires**
+
+Run:
+
+```bash
+nix eval --impure --expr '
+let f = builtins.getFlake (toString ./.);
+in (f.lib.mkHomeManagerSystem {
+  system = "aarch64-darwin";
+  user = "t";
+  directory = "/Users/t";
+  home = {
+    home.stateVersion = "23.05";
+    dotfiles.profiles.base = false;
+    dotfiles.programs.paseo = {
+      enable = true;
+      hostnames = [ "a.lan" ];
+      allowAnyHostname = true;
+    };
+  };
+}).config.home.activationPackage' 2>&1 | tail -5
+```
+
+Expected: FAIL with `mutually exclusive` in the message. (`assertions` are only enforced when the activation package is built, which is why this evaluates that attribute rather than the config directly.)
+
+- [ ] **Step 7: Format check**
+
+Run: `nixfmt --check flake.nix home/programs/paseo.nix`
+Expected: no output, exit 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add flake.nix home/programs/paseo.nix
+git commit -m "home/programs/paseo: add hostname allowlist options
+
+Bean: dotfiles-oelc"
+```

--- a/.beans/dotfiles-p1pz--add-extrapath-and-environment-options-to-the-paseo.md
+++ b/.beans/dotfiles-p1pz--add-extrapath-and-environment-options-to-the-paseo.md
@@ -1,0 +1,117 @@
+---
+# dotfiles-p1pz
+title: Add extraPath and environment options to the paseo module
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-19T10:57:04Z
+updated_at: 2026-08-19T10:57:08Z
+parent: dotfiles-ltuq
+blocked_by:
+    - dotfiles-lpk0
+---
+
+**Files:**
+- Modify: `home/programs/paseo.nix` — options block, `servicePath`, `serviceEnv`
+- Modify: `flake.nix` — the scratch config inside `mkPaseoModuleCheck`
+
+These are the two escape hatches. `environment` is how a host sets things like `BROWSER` for agent hooks; `extraPath` is how it prepends a directory the computed default does not cover.
+
+**Important asymmetry to preserve:** `environment` is merged **last** so it can override any `PASEO_*` variable — but it cannot override `PATH`, because the launcher `export`s the computed PATH *after* the unit environment is applied. `extraPath` is the supported knob for PATH, and the `environment` description must say so.
+
+- [ ] **Step 1: Extend the check's scratch config**
+
+In `flake.nix`, inside `mkPaseoModuleCheck`'s `dotfiles.programs.paseo` block, add:
+
+```nix
+                environment.BROWSER = "/bin/true";
+                extraPath = [ "/opt/paseo/bin" ];
+```
+
+and add these two lines to the `runCommandLocal` script, before `touch $out`:
+
+```bash
+          grep -F 'BROWSER' ${unit}
+          grep -F '/opt/paseo/bin' ${launcher}
+```
+
+- [ ] **Step 2: Run the check to verify it fails**
+
+Run: `nix build .#checks.aarch64-darwin.paseo-module --no-link 2>&1 | tail -5`
+Expected: FAIL with `The option 'dotfiles.programs.paseo.environment' does not exist`.
+
+- [ ] **Step 3: Add the options**
+
+In `home/programs/paseo.nix`, add to `options.dotfiles.programs.paseo` after `port`:
+
+```nix
+    environment = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example = lib.literalExpression ''{ BROWSER = "\''${pkgs.wsl-open}/bin/wsl-open"; }'';
+      description = ''
+        Extra environment variables for the daemon, and so for every agent
+        process it spawns. Merged last, so these override the PASEO_* variables
+        the module derives from the other options.
+
+        PATH is the exception: the launcher exports the computed PATH after this
+        environment is applied, so a PATH set here is silently overwritten. Use
+        `extraPath` instead.
+      '';
+    };
+
+    extraPath = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "/opt/homebrew/bin" ];
+      description = ''
+        Directories prepended to the daemon's PATH, ahead of `~/.local/bin` and
+        the Nix profile directories. The list is de-duplicated, order preserved.
+      '';
+    };
+```
+
+- [ ] **Step 4: Thread them through**
+
+In the same file, prepend `cfg.extraPath` in `servicePath`:
+
+```nix
+  servicePath = lib.concatStringsSep ":" (
+    lib.unique (
+      cfg.extraPath
+      ++ [ "${config.home.homeDirectory}/.local/bin" ]
+      ++ config.home.sessionPath
+      ++ [ "${config.home.profileDirectory}/bin" ]
+      ++ systemPaths
+    )
+  );
+```
+
+and merge `cfg.environment` last in `serviceEnv`:
+
+```nix
+  serviceEnv = {
+    PASEO_HOME = cfg.dataDir;
+    PASEO_LISTEN = "${cfg.listenAddress}:${toString cfg.port}";
+  }
+  // cfg.environment;
+```
+
+- [ ] **Step 5: Run the check to verify it passes**
+
+Run: `nix build .#checks.aarch64-darwin.paseo-module --no-link`
+Expected: PASS (no output, exit 0).
+
+- [ ] **Step 6: Format check**
+
+Run: `nixfmt --check flake.nix home/programs/paseo.nix`
+Expected: no output, exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add flake.nix home/programs/paseo.nix
+git commit -m "home/programs/paseo: add extraPath and environment options
+
+Bean: dotfiles-p1pz"
+```

--- a/.beans/dotfiles-pg0j--paseo-package-wiring.md
+++ b/.beans/dotfiles-pg0j--paseo-package-wiring.md
@@ -1,0 +1,22 @@
+---
+# dotfiles-pg0j
+title: paseo package wiring
+status: todo
+type: feature
+created_at: 2026-08-19T10:54:38Z
+updated_at: 2026-08-19T10:54:38Z
+parent: dotfiles-7043
+---
+
+Brings paseo into the flake as a patched package at `pkgs.dotfiles.paseo`.
+
+Owns:
+- `flake.nix` — the `paseo` input and its entry in `defaultOverlays`
+- `overlays/paseo.nix` — NEW top-level directory; the overlay fragment carrying both upstream patches
+
+Upstream does not build as tagged, so two patches ride along, both re-verified against v0.3.1 and v0.4.0 (whose `nix/package.nix` files are byte-identical):
+
+1. A stale `nix/npm-deps.hash` at every release tag.
+2. Missing `node-pty` prebuilds in `$out`, which breaks every terminal pane.
+
+Landing at `pkgs.dotfiles.paseo` deliberately pulls paseo into `mkPackages`, and therefore into `packages.*` and `checks.*`, so `nix flake check` builds it. That is the only thing that catches a stale hash after a nixpkgs or paseo bump.

--- a/.beans/dotfiles-rdkr--add-overlayspaseonix-exposing-pkgsdotfilespaseo.md
+++ b/.beans/dotfiles-rdkr--add-overlayspaseonix-exposing-pkgsdotfilespaseo.md
@@ -1,0 +1,123 @@
+---
+# dotfiles-rdkr
+title: Add overlays/paseo.nix exposing pkgs.dotfiles.paseo
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-19T10:55:26Z
+updated_at: 2026-08-19T10:59:27Z
+parent: dotfiles-pg0j
+blocked_by:
+    - dotfiles-l710
+---
+
+**Files:**
+- Create: `overlays/paseo.nix` (new top-level `overlays/` directory)
+- Modify: `flake.nix` — the `defaultOverlays` list
+
+Context: upstream's `nix/package.nix` exposes `npmDepsHash` as a **function argument** precisely so downstream flakes on a different nixpkgs can supply their own. `buildNpmPackage` destructures it, so `overrideAttrs` cannot reach it — `callPackage` with an explicit argument is the supported route, and is cleaner than the `npmDeps.overrideAttrs` hack in `sys-warbird`.
+
+The overlay must be appended **after** `dotfilesOverlay` in `defaultOverlays`, because that one plain-assigns `dotfiles` and would otherwise clobber this. Extending with `(prev.dotfiles or { }) // { ... }` matches `crates/default.nix`.
+
+- [ ] **Step 1: Create `overlays/paseo.nix` with a placeholder hash**
+
+```nix
+# A nixpkgs overlay fragment (not a buildable package) exposing a patched paseo
+# as `pkgs.dotfiles.paseo`. Upstream does not build as tagged, so two patches
+# ride along. Re-verified against v0.3.1 and v0.4.0, whose `nix/package.nix`
+# files are byte-identical -- neither patch is close to landing upstream.
+{ inputs }:
+final: prev:
+let
+  paseo =
+    (final.callPackage "${inputs.paseo}/nix/package.nix" {
+      # Every release tag ships a stale `nix/npm-deps.hash`. Two upstream
+      # mechanics combine: `fetchNpmDeps` copies package-lock.json into its
+      # fixed-output result, so the version-string churn in `chore(release): cut
+      # X` moves the hash even when the dependency set is byte-identical; and
+      # the workflow that repairs it triggers on push to main, landing ~10min
+      # *after* the release commit is tagged. So the tag always points at the
+      # pre-repair state (holds for v0.2.5, v0.3.0, v0.3.1).
+      #
+      # Expect to re-point this at every bump rather than to drop it: take the
+      # `got:` hash from the failing build. Overriding is safe either way --
+      # package-lock.json's integrity fields pin the fetched contents
+      # independently of this hash.
+      npmDepsHash = "sha256-oXz8hMk+5DlTYK8OndUAjB+RJMDbPqobVGXLFeoH++o=";
+    }).overrideAttrs
+      (old: {
+        # scripts/trace-daemon.mjs walks the JS module graph, so node-pty's
+        # prebuilt native binding never makes it into $out and every terminal
+        # pane reports "Terminal worker not running". Same cp as upstream PR
+        # #3250; drop this once that (or a real trace fix) lands in a release.
+        postInstall = (old.postInstall or "") + ''
+          mkdir -p "$out/lib/paseo/packages/server/node_modules/node-pty"
+          cp -r packages/server/node_modules/node-pty/prebuilds \
+            "$out/lib/paseo/packages/server/node_modules/node-pty/"
+        '';
+      });
+in
+{
+  # Extend (not clobber) the set `dotfilesOverlay` assigns. This overlay must
+  # come after it in `defaultOverlays`.
+  dotfiles = (prev.dotfiles or { }) // { inherit paseo; };
+}
+```
+
+The starting hash is `sys-warbird`'s current value. It was computed against paseo's own nixpkgs-unstable rather than this repo's nixpkgs 26.05, so it may well not match — Step 4 resolves the real one.
+
+- [ ] **Step 2: Wire it into `defaultOverlays`**
+
+In `flake.nix`, append to the `defaultOverlays` list (after the `crates` entry):
+
+```nix
+      defaultOverlays = [
+        inputs.alacritty-themes.overlays.default
+        dotfilesOverlay
+        (import ./crates { inherit inputs; })
+        (import ./overlays/paseo.nix { inherit inputs; })
+      ];
+```
+
+- [ ] **Step 3: Verify the attribute exists (eval only, no build)**
+
+Run: `nix eval --raw .#packages.aarch64-darwin.paseo.name`
+Expected: `paseo-0.3.1`
+
+If this errors with `attribute 'paseo' missing`, the overlay is ordered before `dotfilesOverlay` or the `dotfiles` merge is wrong.
+
+- [ ] **Step 4: Resolve the real `npmDepsHash`**
+
+Run: `nix build .#packages.aarch64-darwin.paseo --no-link 2>&1 | tail -20`
+
+Two possible outcomes:
+
+- It builds. The starting hash was correct; go to Step 5.
+- It fails with a hash mismatch:
+
+  ```
+  error: hash mismatch in fixed-output derivation '/nix/store/...-paseo-0.3.1-npm-deps.drv':
+           specified: sha256-oXz8hMk+5DlTYK8OndUAjB+RJMDbPqobVGXLFeoH++o=
+              got:    sha256-<actual>
+  ```
+
+  Copy the `got:` value into `npmDepsHash` in `overlays/paseo.nix` and re-run the build. This is the expected workflow at every bump, not a one-off.
+
+- [ ] **Step 5: Verify the node-pty patch landed**
+
+Run: `ls $(nix build .#packages.aarch64-darwin.paseo --no-link --print-out-paths)/lib/paseo/packages/server/node_modules/node-pty/prebuilds`
+Expected: a non-empty directory listing. An empty result or `No such file` means the `postInstall` did not apply.
+
+- [ ] **Step 6: Format check**
+
+Run: `nixfmt --check flake.nix overlays/paseo.nix`
+Expected: no output, exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add flake.nix overlays/paseo.nix
+git commit -m "overlays: add patched paseo as pkgs.dotfiles.paseo
+
+Bean: dotfiles-rdkr"
+```

--- a/.beans/dotfiles-yhib--document-the-overlays-directory-in-claudemd.md
+++ b/.beans/dotfiles-yhib--document-the-overlays-directory-in-claudemd.md
@@ -1,0 +1,65 @@
+---
+# dotfiles-yhib
+title: Document the overlays/ directory in CLAUDE.md
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-19T10:58:19Z
+updated_at: 2026-08-19T10:58:25Z
+parent: dotfiles-yk15
+blocked_by:
+    - dotfiles-rdkr
+---
+
+**Files:**
+- Modify: `CLAUDE.md` — the freshness date, the Project Structure tree, the Packages convention section
+
+`overlays/` is a new top-level directory, and it introduces a second route by which something lands under `pkgs.dotfiles.*` — an overlay fragment wrapping an upstream flake input, rather than an auto-discovered `packages/` directory. Both routes end at the same namespace, and the existing convention text only describes the first.
+
+- [ ] **Step 1: Bump the freshness date**
+
+Change the line near the top of `CLAUDE.md`:
+
+```
+Freshness: 2026-08-19
+```
+
+- [ ] **Step 2: Add `overlays/` to the Project Structure tree**
+
+In the fenced tree block, after the `modules/` line, add:
+
+```
+overlays/            # Overlay fragments wrapping upstream flake inputs (paseo)
+```
+
+- [ ] **Step 3: Extend the Packages convention section**
+
+In the `### Packages` section, after the paragraph ending "Reference them as `pkgs.dotfiles.claude-code`, not `pkgs.claude-code`.", add:
+
+```markdown
+Upstream software we consume as a flake input rather than build from a `packages/`
+directory lands in the same namespace, via an overlay fragment under `overlays/`
+that extends the set rather than clobbering it — `dotfiles = (prev.dotfiles or { })
+// { ... }`, the same shape `crates/default.nix` uses. Such an overlay must be
+listed in `defaultOverlays` **after** `dotfilesOverlay`, which plain-assigns
+`dotfiles`. `pkgs.dotfiles.paseo` is the current example; it carries two patches
+upstream has not landed, so expect its `npmDepsHash` to need re-pointing at every
+version bump.
+```
+
+- [ ] **Step 4: Verify the claims are still true**
+
+Run: `grep -n "overlays/paseo.nix" flake.nix`
+Expected: one line, inside `defaultOverlays`, positioned after the `dotfilesOverlay` entry.
+
+Run: `nix eval --raw .#packages.aarch64-darwin.paseo.name`
+Expected: `paseo-0.3.1`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "CLAUDE.md: document the overlays/ directory
+
+Bean: dotfiles-yhib"
+```

--- a/.beans/dotfiles-yk15--paseo-docs.md
+++ b/.beans/dotfiles-yk15--paseo-docs.md
@@ -1,0 +1,14 @@
+---
+# dotfiles-yk15
+title: paseo docs
+status: todo
+type: feature
+created_at: 2026-08-19T10:54:38Z
+updated_at: 2026-08-19T10:54:38Z
+parent: dotfiles-7043
+---
+
+Documents the new `overlays/` directory and the convention it establishes.
+
+Owns:
+- `CLAUDE.md` — the Project Structure tree, the Packages convention section, and the freshness date

--- a/docs/specs/2026-08-19-paseo-home-manager-module.md
+++ b/docs/specs/2026-08-19-paseo-home-manager-module.md
@@ -1,0 +1,329 @@
+# Paseo home-manager module — spec
+
+Date: 2026-08-19
+
+Pull [paseo](https://github.com/getpaseo/paseo) into this flake as a patched package
+(`pkgs.dotfiles.paseo`) and a home-manager module (`dotfiles.programs.paseo`) that runs
+the daemon as a user service — `systemd.user` on Linux, `launchd` agent on macOS.
+
+Today this wiring lives downstream in `sys-warbird` as a flake input, a patch overlay,
+and upstream's NixOS-only `services.paseo` module plus two `mkForce` escape hatches.
+Upstream has no home-manager or darwin support, and its package does not build at any
+release tag as-shipped.
+
+## Goals
+
+- Expose a patched paseo at `pkgs.dotfiles.paseo`, built against this repo's pinned
+  nixpkgs, so a stale `npmDepsHash` fails in CI rather than at switch time on a host.
+- Provide `home/programs/paseo.nix` following the repo's program-module pattern,
+  covering both `systemd.user` and `launchd` from one module.
+- Support `listenAddress`, `port`, a daemon password (both a plain option and a
+  file-based one), and arbitrary extra environment variables.
+- Make `~/.local/bin` reachable by the daemon and the agents it spawns *by default*, so
+  the `claude` / `codex` wrappers work without a downstream `mkForce`.
+
+## Non-goals
+
+- No changes to `sys-warbird`. Cutting it over to this module is deliberately deferred
+  to separate, later work. The module must be *capable* of everything that repo does
+  today, but nothing there changes here.
+- No relay support. `--no-relay` is passed unconditionally and no relay options are
+  exposed.
+- No `settings` / `config.json` rendering. Upstream warns declarative config.json
+  clobbers CLI and mobile-app mutations on every restart; config.json stays purely
+  runtime-managed.
+- No system-level (NixOS / nix-darwin) module, and no new `nixosModules` /
+  `darwinModules` flake outputs.
+- No `user` / `group` / `openFirewall` / `inheritUserEnvironment` options — meaningless
+  or unavailable in home-manager.
+- No configuration of the `paseo` **CLI**'s connection target (`PASEO_HOST`) for
+  interactive shells. See "Out of scope follow-ups".
+
+## Upstream facts this design depends on
+
+Verified against `getpaseo/paseo` at v0.3.1 and v0.4.0:
+
+1. `nix/module.nix` is NixOS-only — `systemd.services`, `users.users`, `users.groups`,
+   `networking.firewall`. No launchd, no `systemd.user`, no home-manager support.
+2. `nix/package.nix` is **byte-identical** between v0.3.1 and v0.4.0, so both patches
+   below are still required and neither is close to landing upstream.
+3. `PASEO_PASSWORD` is read as **plaintext** and bcrypt-hashed at startup
+   (`packages/server/src/server/config.ts:409`). There is no hashed-input env var.
+4. Hostname allowlisting matches on the **`Host` header**, not the bind address
+   (`packages/server/src/server/hostnames.ts`). Defaults allow `localhost`,
+   `*.localhost`, and any literal IP. A disallowed host fails the websocket upgrade
+   with `403 Host not allowed` (`websocket-server.ts:832`).
+5. `nix/package.nix` exposes `npmDepsHash` as a **function argument** specifically so
+   downstream flakes on a different nixpkgs can override it without `overrideAttrs`
+   (`npmDepsHash` is destructured by `buildNpmPackage`, so `overrideAttrs` cannot reach
+   it).
+6. The server is not published to npm (`@getpaseo/cli` is; the `paseo` npm package is
+   unrelated), so building from the flake input source is the only practical route.
+
+Home-manager option types verified at the pinned rev (`4baa8ac`):
+
+- `systemd.user.services.<n>.Service.Environment` is `coercedTo str toList (listOf str)`
+  — an **attrset is not accepted**; env must be rendered to `"KEY=value"` strings.
+- `launchd.agents.<n>.config.EnvironmentVariables` is `nullOr (attrsOf str)`.
+
+## Package wiring
+
+### `flake.nix` input
+
+```nix
+paseo = {
+  url = "github:getpaseo/paseo/v0.3.1";
+  inputs.nixpkgs.follows = "nixpkgs";
+};
+```
+
+### `overlays/paseo.nix` (new directory)
+
+A new top-level `overlays/` directory, holding overlay fragments that are not
+`packages/`-style local derivations. `flake.nix` appends
+`(import ./overlays/paseo.nix { inherit inputs; })` to `defaultOverlays`, **after**
+`dotfilesOverlay` (which plain-assigns `dotfiles` and would otherwise clobber this).
+
+The overlay extends rather than replaces the set, matching `crates/default.nix`:
+
+```nix
+{ inputs }:
+final: prev:
+let
+  paseo = (final.callPackage "${inputs.paseo}/nix/package.nix" {
+    npmDepsHash = "sha256-…";
+  }).overrideAttrs (old: {
+    postInstall = (old.postInstall or "") + ''…'';
+  });
+in
+{
+  dotfiles = (prev.dotfiles or { }) // { inherit paseo; };
+}
+```
+
+Two patches are carried, each with the explanatory comment from
+`sys-warbird/overlays/paseo.nix` adapted to the new mechanism:
+
+1. **`npmDepsHash`.** The correct value is not knowable ahead of the build. Start from
+   `lib.fakeHash`, build once, and take the `got:` hash from the failure — that is the
+   expected workflow at every bump, not a one-off. `sys-warbird`'s current value
+   (`sha256-oXz8hMk+5DlTYK8OndUAjB+RJMDbPqobVGXLFeoH++o=`) is worth trying first, but it
+   was computed with paseo's own nixpkgs-unstable rather than this repo's `nixpkgs`
+   26.05, so it may well not match. Every release tag ships a stale
+   `nix/npm-deps.hash`: upstream's
+   repair workflow runs on push to `main` and lands ~10 minutes *after* the release
+   commit is tagged, so the tag always points at the pre-repair state (holds for v0.2.5,
+   v0.3.0, v0.3.1). Passing it as a `callPackage` argument — rather than
+   `sys-warbird`'s `npmDeps.overrideAttrs` — is the mechanism upstream provides for
+   this. Expect to re-point it at every bump. Overriding is safe: `package-lock.json`'s
+   integrity fields pin the fetched contents independently of this hash.
+2. **`node-pty` prebuilds.** `scripts/trace-daemon.mjs` walks the JS module graph, so
+   node-pty's prebuilt native binding never reaches `$out` and every terminal pane
+   reports "Terminal worker not running". Same `cp` as upstream PR #3250.
+
+Landing at `pkgs.dotfiles.paseo` means `mkPackages` (`removeAttrs pkgs.dotfiles
+[ "internal" ]`) picks it up, so paseo enters `packages.*` **and** `checks.*` and
+`nix flake check` builds it. That is a deliberate, several-minute-per-PR cost: it is the
+only thing that catches a stale `npmDepsHash` after a nixpkgs or paseo bump. CI runs on
+`ubuntu-latest`, so only the `x86_64-linux` build is exercised; the darwin build stays
+evaluation-only until someone switches a Mac.
+
+## Module: `home/programs/paseo.nix`
+
+Standard repo pattern — `options.dotfiles.programs.paseo` + `config = lib.mkIf
+cfg.enable { … }`. Not added to any profile in `home/profiles.nix`; opt-in per host.
+
+### Options
+
+| Option | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `enable` | `bool` | `false` | `mkEnableOption` |
+| `package` | `package` | `pkgs.dotfiles.paseo` | `mkPackageOption`-style |
+| `dataDir` | `str` | `"${config.home.homeDirectory}/.paseo"` | → `PASEO_HOME` |
+| `listenAddress` | `str` | `"127.0.0.1"` | → `PASEO_LISTEN` with `port` |
+| `port` | `port` | `6767` | |
+| `hostnames` | `listOf str` | `[ ]` | → `PASEO_HOSTNAMES`, omitted when empty |
+| `allowAnyHostname` | `bool` | `false` | → `PASEO_HOSTNAMES=true` |
+| `password` | `nullOr str` | `null` | Store-visible; documented as such |
+| `passwordFile` | `nullOr path` | `null` | Read at process start |
+| `environment` | `attrsOf str` | `{ }` | Arbitrary extra env |
+| `extraPath` | `listOf str` | `[ ]` | Prepended to the computed PATH |
+
+Option descriptions must carry these specifics, because each is a real trap:
+
+- `hostnames` — matched against the `Host` header, **not** the bind address. Additive to
+  the built-in `localhost` / `*.localhost` / any-literal-IP defaults, never a
+  replacement. Reaching the daemon at `http://warbird.lan:6767` requires
+  `hostnames = [ "warbird.lan" ]`; `http://192.168.1.5:6767` needs nothing. A rejected
+  host fails the websocket upgrade with `403 Host not allowed`, which typically presents
+  as "the UI loads but never connects".
+- `allowAnyHostname` — disables DNS-rebinding protection entirely; any web page you
+  visit can then reach the daemon by name.
+- `password` — the value is written into the Nix store, which is world-readable on the
+  host. Prefer `passwordFile`.
+- `passwordFile` — a path **outside** the store containing the plaintext password and
+  nothing else. Read at each service start, so rotating the secret needs only a service
+  restart, not a home-manager switch.
+
+### Assertions
+
+- `password` and `passwordFile` are mutually exclusive.
+- `hostnames != [ ]` and `allowAnyHostname` are mutually exclusive.
+
+### Launcher script
+
+One `pkgs.writeShellScript "paseo-launcher"`, shared by both platforms, because launchd
+has no `EnvironmentFile` equivalent and this is the only way `passwordFile` behaves
+identically on macOS and Linux:
+
+```sh
+set -euo pipefail
+export PATH="<computed>"
+mkdir -p "$PASEO_HOME"
+chmod 700 "$PASEO_HOME"
+# only when passwordFile != null:
+PASEO_PASSWORD="$(cat <passwordFile>)"
+export PASEO_PASSWORD
+exec <package>/bin/paseo-server --no-relay
+```
+
+- `set -euo pipefail` makes a missing or unreadable `passwordFile` a loud startup
+  failure rather than a silently unauthenticated daemon.
+- `mkdir -p` replaces upstream's `systemd.tmpfiles` rule, which home-manager has no
+  equivalent for. `chmod 700` matches upstream's `0700`.
+- `--no-relay` is unconditional.
+- The `PASEO_PASSWORD` block is emitted only when `passwordFile != null`; `password`
+  (the plain option) goes through the normal environment path instead.
+
+PATH is computed as:
+
+```
+cfg.extraPath
+  ++ [ "${config.home.homeDirectory}/.local/bin" ]
+  ++ config.home.sessionPath
+  ++ [ "${config.home.profileDirectory}/bin" ]
+  ++ <platform system paths>
+```
+
+`~/.local/bin` is explicit and unconditional: `home/programs/claude-code/default.nix`
+and `home/programs/codex/default.nix` both install their wrappers there via
+`home.activation`, and no Nix profile directory covers it. This is precisely the
+`mkForce` that `sys-warbird` currently carries.
+
+Platform system paths:
+
+- Linux: `/etc/profiles/per-user/<user>/bin`, `/run/current-system/sw/bin`,
+  `/run/wrappers/bin`, `/nix/var/nix/profiles/default/bin`
+- Darwin: `/etc/profiles/per-user/<user>/bin`, `/run/current-system/sw/bin`,
+  `/nix/var/nix/profiles/default/bin`, `/usr/bin`, `/bin`, `/usr/sbin`, `/sbin`
+
+The list is de-duplicated (`lib.unique`) while preserving order.
+
+### Environment
+
+Non-secret variables go through each platform's native mechanism so they stay
+introspectable via `systemctl --user show-environment` / `launchctl print`:
+
+```
+PASEO_HOME       = cfg.dataDir
+PASEO_LISTEN     = "${cfg.listenAddress}:${toString cfg.port}"
+PASEO_HOSTNAMES  = "true" | concatStringsSep "," cfg.hostnames   # omitted when neither applies
+PASEO_PASSWORD   = cfg.password                                  # only when non-null
+<cfg.environment>                                                # merged last, wins
+```
+
+`cfg.environment` is merged last so it can override any of the `PASEO_*` variables above
+— that is what makes it a real escape hatch (it is how `sys-warbird` sets `BROWSER`).
+
+**`PATH` is the one exception.** The launcher `export`s the computed PATH *after* the
+unit environment has been applied, so a `PATH` entry in `cfg.environment` is silently
+overwritten rather than honoured. `extraPath` is the supported knob, and the
+`environment` option's description must say so explicitly — a silently-ignored PATH
+override is exactly the kind of thing that costs an afternoon.
+
+Rendering differs per platform, per the verified option types: Linux maps the attrset to
+`[ "KEY=value" ]` with `lib.escapeShellArg` on each value (systemd's `Environment=`
+performs shell-like unquoting, so values containing spaces must be quoted); darwin
+passes the attrset straight to `EnvironmentVariables`.
+
+### Services
+
+- **launchd** (`lib.mkIf pkgs.stdenv.isDarwin`), mirroring `beans-daemon.nix`:
+  `ProgramArguments = [ launcher ]`, `KeepAlive = true`, `RunAtLoad = true`,
+  `EnvironmentVariables`, and `StandardOutPath` / `StandardErrorPath` at
+  `${config.home.homeDirectory}/Library/Logs/paseo.log`.
+- **systemd user** (`lib.mkIf pkgs.stdenv.isLinux`):
+  `Unit.Description`, `Unit.After = [ "network.target" ]`,
+  `Service.ExecStart = launcher`, `Service.Environment`,
+  `Service.Restart = "on-failure"`, `Service.RestartSec = 5`,
+  `Service.KillSignal = "SIGTERM"`, `Service.TimeoutStopSec = 15` (upstream's graceful
+  shutdown window — the server handles SIGTERM with a 10s timeout),
+  `Install.WantedBy = [ "default.target" ]`.
+
+`home.packages = [ cfg.package ]` so the `paseo` CLI is available interactively, not
+just the daemon.
+
+The module's `enable` description notes that a systemd **user** service only survives
+logout when `users.users.<name>.linger = true`, which home-manager cannot set — it is a
+downstream system-config requirement.
+
+## File layout
+
+```
+flake.nix                    # + paseo input, + overlay in defaultOverlays, + module check
+overlays/                    # NEW directory
+  paseo.nix                  # NEW — patched pkgs.dotfiles.paseo
+home/programs/paseo.nix      # NEW — the module (auto-imported by home/default.nix)
+CLAUDE.md                    # + overlays/ in Project Structure, + convention note
+```
+
+## Validation
+
+1. `nix flake check` — now also builds `pkgs.dotfiles.paseo` on `x86_64-linux`, plus the
+   existing `nixfmt` gate over the new files.
+2. **Module eval check**, a new `checks.x86_64-linux.paseo-module`: evaluate a minimal
+   `homeManagerConfiguration` (with `dotfiles.profiles.base = false` to keep it cheap)
+   that enables the module with a non-default `listenAddress`, `port`, `passwordFile`,
+   `hostnames`, and `environment`. Home-manager materialises user units through
+   `xdg.configFile` (`modules/systemd.nix:458`), so the rendered unit is reachable at
+   `hmConfig.config.xdg.configFile."systemd/user/paseo.service".source` — a plain store
+   path a `runCommandLocal` can `grep` without building the activation package (and
+   therefore without building paseo itself a second time). Assert:
+   - `PASEO_LISTEN=` carrying the configured address and port
+   - `PASEO_HOSTNAMES=` carrying the configured names
+   - the `environment` escape-hatch variable
+   - `--no-relay` in the launcher
+   - `/.local/bin` in the launcher's PATH
+   - the `passwordFile` read, and **absence** of any plaintext password in the store
+
+   Linux-only: it asserts the systemd path, and CI has no darwin builder. The launchd
+   path is covered by evaluation alone (`nix flake show` / `packages.aarch64-darwin`).
+3. Manual, on a real host, deferred with the `sys-warbird` cutover: daemon starts, UI
+   connects, a spawned agent can find `claude` on PATH, and a terminal pane works (the
+   node-pty patch).
+
+## Risk / rollback
+
+- **`npmDepsHash` churn** is the known recurring failure. It is now a CI failure with
+  the correct value in the build log's `got:` line, rather than a switch-time failure on
+  a host. Bumping the input and the hash together is the expected maintenance.
+- **CI time** grows by a full npm + node-gyp + sherpa build of paseo. Accepted: binary
+  caching is planned for this repo, at which point the build happens once per bump
+  rather than once per PR. No mitigation is designed in.
+- **Nothing downstream changes**, so rollback is deleting the three new files and
+  reverting `flake.nix` and `CLAUDE.md`. `sys-warbird` keeps working off its own input
+  and overlay throughout.
+
+## Out of scope follow-ups
+
+Worth beans of their own, not built here:
+
+- `sys-warbird` cutover: drop its `paseo` input, `overlays/paseo.nix`, the
+  `services.paseo` block and both `mkForce` escape hatches; enable
+  `dotfiles.programs.paseo` in `home.nix` with `environment.BROWSER` carrying the
+  `wsl-open` value.
+- CLI connection config: a `PASEO_HOST` session variable so the `paseo` CLI targets a
+  non-default `port` without the user exporting it by hand.
+- Relay support, if a self-hosted relay ever appears.
+- An `update.sh`-style nightly bump for the paseo input + hash, matching the
+  `packages/*/update.sh` convention.


### PR DESCRIPTION
Lands the planning artifacts for pulling [paseo](https://github.com/getpaseo/paseo) into this flake: a spec plus the beans tree that decomposes it.

No functional change — no Nix, no Rust, nothing wired into a profile. The implementation happens in the beans this adds.

## What it plans

`pkgs.dotfiles.paseo` (a patched build of the flake input) plus a `dotfiles.programs.paseo` home-manager module that runs the daemon as a **user** service — `systemd.user` on Linux, launchd agent on macOS. Upstream ships a NixOS-only module, so the home-manager and darwin support is ours.

Options cover `listenAddress` / `port` / `dataDir`, a daemon password (both a store-visible `password` and a `passwordFile` read at process start), hostname allowlisting, and `environment` / `extraPath` escape hatches. Relay is hardcoded off; no `config.json` rendering.

## Notable decisions

- **Both patches upstream needs come with us.** Re-verified against v0.3.1 and v0.4.0, whose `nix/package.nix` files are byte-identical: every release tag ships a stale `nix/npm-deps.hash`, and `node-pty`'s prebuilds never reach `$out`. Pinned to v0.3.1.
- **`pkgs.dotfiles.paseo`, not a top-level attribute.** That pulls paseo into `checks.*` so `nix flake check` builds it — deliberate, since that build is the only thing that catches a stale `npmDepsHash` after a nixpkgs bump.
- **One shared launcher script** drives both launchers. It is the only mechanism where `passwordFile` behaves identically on macOS, since launchd has no `EnvironmentFile`. It also makes `~/.local/bin` reachable by default, replacing the `mkForce` PATH workaround downstream configs carry today.
- **`sys-warbird` is not migrated here.** Deferred by design.

## Follow-ups

Recorded in the spec's "Out of scope follow-ups", no beans cut yet: the `sys-warbird` cutover, `PASEO_HOST` for the CLI, relay support, and a nightly input+hash bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)