### PR TITLE
overlays: wire paseo in as pkgs.dotfiles.paseo

### DIFF
--- a/.beans/dotfiles-egs1--paseo-npmdepshash-must-satisfy-both-nixpkgs-pins-b.md
+++ b/.beans/dotfiles-egs1--paseo-npmdepshash-must-satisfy-both-nixpkgs-pins-b.md
@@ -1,0 +1,55 @@
+---
+# dotfiles-egs1
+title: paseo npmDepsHash must satisfy both nixpkgs pins, but CI only checks linux
+status: todo
+type: task
+created_at: 2026-08-19T12:44:49Z
+updated_at: 2026-08-19T12:44:49Z
+parent: dotfiles-pg0j
+---
+
+Raised during review of `dotfiles-l710` (the `paseo` flake input). Not a defect in
+that diff — a design gap to resolve while implementing `dotfiles-rdkr`
+(`overlays/paseo.nix`).
+
+## The gap
+
+This repo carries **two** nixpkgs pins:
+
+- `inputs.nixpkgs` — `nixos-26.05`, used by `nixOsPkgs`
+- `inputs.nixpkgs-darwin` — `nixpkgs-26.05-darwin`, used by `nixDarwinPkgs` (`flake.nix`)
+
+`overlays/paseo.nix` will build paseo via `final.callPackage`, so
+`pkgs.dotfiles.paseo` is built against **whichever nixpkgs `final` came from** — a
+different revision per platform. A single hardcoded `npmDepsHash` must therefore be
+valid under *both* pins.
+
+Note the input's `inputs.nixpkgs.follows = "nixpkgs"` does **not** control this: the
+overlay consumes `inputs.paseo` as a source tree (`"${inputs.paseo}/nix/package.nix"`),
+so paseo's own flake outputs never evaluate. The follows only keeps a second `nixpkgs`
+node out of `flake.lock`.
+
+## Why it matters
+
+`.github/workflows/ci.yml` runs `nix flake check` on `ubuntu-latest` only, so **just the
+linux/`nixpkgs` build is ever exercised in CI** — while the machine that actually runs
+paseo is darwin. Failure mode: green CI, then a local darwin `nix flake check` failing on
+a hash mismatch after a routine `nix flake update` moves the two pins independently.
+
+This also qualifies the epic's claim that landing at `pkgs.dotfiles.paseo` pulls paseo
+into `checks.*` so "`nix flake check` builds it — the only thing that catches a stale
+hash". True for one platform, not both.
+
+Both pins are on the same 26.05 branch, so `prefetch-npm-deps` is very likely
+byte-identical today — this is low-probability, not hypothetical-impossible. Nothing in
+the design *ensures* it.
+
+## Options to weigh
+
+- [ ] Confirm empirically whether the hash differs across the two pins (build
+      `pkgs.dotfiles.paseo` under both `nixOsPkgs` and `nixDarwinPkgs`).
+- [ ] Decide the resolution: accept and document the risk in `overlays/paseo.nix`; or add
+      a darwin runner to CI; or pin paseo's build to one nixpkgs explicitly so the hash
+      has a single owner.
+- [ ] Record the outcome as a comment in `overlays/paseo.nix` next to `npmDepsHash`, so
+      the next person bumping the pin knows which platforms the hash was verified against.

--- a/.beans/dotfiles-egs1--paseo-npmdepshash-must-satisfy-both-nixpkgs-pins-b.md
+++ b/.beans/dotfiles-egs1--paseo-npmdepshash-must-satisfy-both-nixpkgs-pins-b.md
@@ -3,8 +3,9 @@
 title: paseo npmDepsHash must satisfy both nixpkgs pins, but CI only checks linux
 status: todo
 type: task
+priority: normal
 created_at: 2026-08-19T12:44:49Z
-updated_at: 2026-08-19T12:44:49Z
+updated_at: 2026-08-19T12:59:39Z
 parent: dotfiles-pg0j
 ---
 
@@ -53,3 +54,32 @@ the design *ensures* it.
       has a single owner.
 - [ ] Record the outcome as a comment in `overlays/paseo.nix` next to `npmDepsHash`, so
       the next person bumping the pin knows which platforms the hash was verified against.
+
+## Measured during dotfiles-rdkr (2026-08-19)
+
+The risk is real in principle but **provably not live today**, which is sharper than the
+"very likely byte-identical" guess above:
+
+- `nixpkgs` is at `b51242d7`, `nixpkgs-darwin` at `6d6863fd` — genuinely different revs.
+- Both nonetheless evaluate `prefetch-npm-deps` to version `0.1.0` built from the
+  **identical source store path**, `/nix/store/zy6a8dbvllbkignnapqc2qfrlsdam61h-source`.
+
+Since the npm-deps FOD's content is that tool's output over the same `package-lock.json`,
+an identical tool source means an identical output hash. The single `npmDepsHash` is
+therefore correct under both pins *as long as the two pins keep resolving
+`prefetch-npm-deps` to the same source* — that, not the nixpkgs rev itself, is the real
+invariant to watch.
+
+Also worth correcting the framing above: coverage is **complementary**, not simply absent.
+`checks.x86_64-linux.paseo` is exercised by CI on ubuntu, and `checks.aarch64-darwin.paseo`
+is exercised whenever `nix flake check` runs locally on darwin. The gap is that the darwin
+half is only ever validated by a human remembering to run it — nothing automates it.
+
+Confirmed empirically on darwin: the hash `sha256-oXz8hMk+5DlTYK8OndUAjB+RJMDbPqobVGXLFeoH++o=`
+builds clean against `nixpkgs-darwin` 26.05. Upstream's v0.3.1 sidecar
+(`sha256-RCp5Ogd8AETLmJCZaUebcgSPRk+is26nkUY7+blDb/g=`) does not match it, which is the
+stale-tag premise holding as described.
+
+So the remaining decision is narrower than first written: decide whether to automate the
+darwin half (darwin runner in CI) or accept it as a local-only gate and say so in
+`overlays/paseo.nix`.

--- a/.beans/dotfiles-l710--add-the-paseo-flake-input-pinned-to-v031.md
+++ b/.beans/dotfiles-l710--add-the-paseo-flake-input-pinned-to-v031.md
@@ -1,11 +1,11 @@
 ---
 # dotfiles-l710
 title: Add the paseo flake input pinned to v0.3.1
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-08-19T10:54:52Z
-updated_at: 2026-08-19T10:54:58Z
+updated_at: 2026-08-19T12:45:32Z
 parent: dotfiles-pg0j
 ---
 
@@ -17,7 +17,7 @@ Context: paseo's own flake pins `nixpkgs-unstable`. We follow our `nixpkgs` so t
 
 Work from inside the devShell (`direnv` shell) so `nixfmt` is on `PATH` for the pre-commit hook.
 
-- [ ] **Step 1: Add the input**
+- [x] **Step 1: Add the input**
 
 In `flake.nix`, inside `inputs`, after the `crane.url` line:
 
@@ -31,12 +31,12 @@ In `flake.nix`, inside `inputs`, after the `crane.url` line:
     };
 ```
 
-- [ ] **Step 2: Lock the input**
+- [x] **Step 2: Lock the input**
 
 Run: `nix flake lock`
 Expected: `warning: updating lock file ...` plus a line adding `paseo`. `flake.lock` is modified.
 
-- [ ] **Step 3: Verify the input resolves and the flake still evaluates**
+- [x] **Step 3: Verify the input resolves and the flake still evaluates**
 
 Run: `nix flake metadata --json | jq -r '.locks.nodes.paseo.locked.rev'`
 Expected: a 40-character commit sha (the v0.3.1 tag's commit), not an error.
@@ -44,12 +44,12 @@ Expected: a 40-character commit sha (the v0.3.1 tag's commit), not an error.
 Run: `nix eval .#lib --apply builtins.attrNames`
 Expected: `[ "mkDarwin" "mkHomeManagerSystem" "mkNixosSystem" "mkShells" ]`
 
-- [ ] **Step 4: Format check**
+- [x] **Step 4: Format check**
 
 Run: `nixfmt --check flake.nix`
 Expected: no output, exit 0.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add flake.nix flake.lock
@@ -57,3 +57,39 @@ git commit -m "flake: add paseo input pinned to v0.3.1
 
 Bean: dotfiles-l710"
 ```
+
+## Summary of Changes
+
+Added the `paseo` flake input to `flake.nix`, after the `crane` entry, pinned to tag
+`v0.3.1` with `inputs.nixpkgs.follows = "nixpkgs"`, and locked it.
+
+- `flake.nix` — 8-line `inputs` entry with a comment recording the coupling to
+  `overlays/paseo.nix` (both must be bumped together, since release tags ship a stale
+  `nix/npm-deps.hash`).
+- `flake.lock` — purely additive: one `paseo` node (`rev bfec7ac3`, the `v0.3.1` tag
+  commit) plus `root.inputs.paseo`. No existing input moved.
+
+Verified: locked rev matches `refs/tags/v0.3.1^{}`; `nix eval .#lib --apply
+builtins.attrNames` still yields `[ "mkDarwin" "mkHomeManagerSystem" "mkNixosSystem"
+"mkShells" ]`; `nixfmt --check flake.nix` clean. The input is inert until
+`overlays/paseo.nix` consumes it — no `packages.*`/`checks.*` surface change.
+
+### Review notes
+
+Subagent review approved with no blocking or required changes; user review requested no
+changes. Two points were raised and deliberately not actioned here:
+
+1. The `follows` does **not** make `npmDepsHash` ours, contrary to this bean's Context
+   paragraph — `dotfiles-rdkr` consumes `inputs.paseo` as a source tree
+   (`"${inputs.paseo}/nix/package.nix"`), so paseo's flake outputs never evaluate and
+   `final` decides the nixpkgs. The follows still earns its keep by keeping a second
+   `nixpkgs` node out of `flake.lock`. Implementation matches the spec as written
+   (`docs/specs/2026-08-19-paseo-home-manager-module.md`); only the recorded rationale is
+   off.
+2. The one hardcoded hash must satisfy both `nixpkgs` and `nixpkgs-darwin`, while CI only
+   runs `nix flake check` on linux — captured as `dotfiles-egs1` to resolve during
+   `dotfiles-rdkr`.
+
+Not landed on its own: held on the shared `feature/paseo-package-wiring` branch to ship
+as one PR with `dotfiles-rdkr`, so the comment's reference to `overlays/paseo.nix` is
+never transiently dangling on `master`.

--- a/.beans/dotfiles-rdkr--add-overlayspaseonix-exposing-pkgsdotfilespaseo.md
+++ b/.beans/dotfiles-rdkr--add-overlayspaseonix-exposing-pkgsdotfilespaseo.md
@@ -1,11 +1,11 @@
 ---
 # dotfiles-rdkr
 title: Add overlays/paseo.nix exposing pkgs.dotfiles.paseo
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-08-19T10:55:26Z
-updated_at: 2026-08-19T10:59:27Z
+updated_at: 2026-08-19T14:15:32Z
 parent: dotfiles-pg0j
 blocked_by:
     - dotfiles-l710
@@ -19,7 +19,7 @@ Context: upstream's `nix/package.nix` exposes `npmDepsHash` as a **function argu
 
 The overlay must be appended **after** `dotfilesOverlay` in `defaultOverlays`, because that one plain-assigns `dotfiles` and would otherwise clobber this. Extending with `(prev.dotfiles or { }) // { ... }` matches `crates/default.nix`.
 
-- [ ] **Step 1: Create `overlays/paseo.nix` with a placeholder hash**
+- [x] **Step 1: Create `overlays/paseo.nix` with a placeholder hash**
 
 ```nix
 # A nixpkgs overlay fragment (not a buildable package) exposing a patched paseo
@@ -66,7 +66,7 @@ in
 
 The starting hash is `sys-warbird`'s current value. It was computed against paseo's own nixpkgs-unstable rather than this repo's nixpkgs 26.05, so it may well not match — Step 4 resolves the real one.
 
-- [ ] **Step 2: Wire it into `defaultOverlays`**
+- [x] **Step 2: Wire it into `defaultOverlays`**
 
 In `flake.nix`, append to the `defaultOverlays` list (after the `crates` entry):
 
@@ -79,14 +79,14 @@ In `flake.nix`, append to the `defaultOverlays` list (after the `crates` entry):
       ];
 ```
 
-- [ ] **Step 3: Verify the attribute exists (eval only, no build)**
+- [x] **Step 3: Verify the attribute exists (eval only, no build)**
 
 Run: `nix eval --raw .#packages.aarch64-darwin.paseo.name`
 Expected: `paseo-0.3.1`
 
 If this errors with `attribute 'paseo' missing`, the overlay is ordered before `dotfilesOverlay` or the `dotfiles` merge is wrong.
 
-- [ ] **Step 4: Resolve the real `npmDepsHash`**
+- [x] **Step 4: Resolve the real `npmDepsHash`**
 
 Run: `nix build .#packages.aarch64-darwin.paseo --no-link 2>&1 | tail -20`
 
@@ -103,17 +103,17 @@ Two possible outcomes:
 
   Copy the `got:` value into `npmDepsHash` in `overlays/paseo.nix` and re-run the build. This is the expected workflow at every bump, not a one-off.
 
-- [ ] **Step 5: Verify the node-pty patch landed**
+- [x] **Step 5: Verify the node-pty patch landed**
 
 Run: `ls $(nix build .#packages.aarch64-darwin.paseo --no-link --print-out-paths)/lib/paseo/packages/server/node_modules/node-pty/prebuilds`
 Expected: a non-empty directory listing. An empty result or `No such file` means the `postInstall` did not apply.
 
-- [ ] **Step 6: Format check**
+- [x] **Step 6: Format check**
 
 Run: `nixfmt --check flake.nix overlays/paseo.nix`
 Expected: no output, exit 0.
 
-- [ ] **Step 7: Commit**
+- [x] **Step 7: Commit**
 
 ```bash
 git add flake.nix overlays/paseo.nix
@@ -121,3 +121,84 @@ git commit -m "overlays: add patched paseo as pkgs.dotfiles.paseo
 
 Bean: dotfiles-rdkr"
 ```
+
+## Review triage (subagent, 2026-08-19)
+
+Verdict was *Needs Discussion* — no blocking defects. Applied:
+
+- **Documented what the hash must satisfy** (the deliverable `dotfiles-egs1` asked for):
+  one hash serves both `inputs.nixpkgs` (linux) and `inputs.nixpkgs-darwin`, valid today
+  only because both pins resolve `prefetch-npm-deps` to the identical source. Also warns
+  that a `got:` hash taken on your own platform is not necessarily right for both.
+- **Narrowed the prebuilds copy to the host triple.** The full tree is 24MB (≈21MB of it
+  win32 debug symbols) to deliver ~140KB; the runtime loader keys strictly on
+  `prebuilds/<platform>-<arch>`. Deviates from upstream PR #3250's whole-tree `cp` on
+  purpose, and says so.
+- **Added a guard that fails the build** if `$out/.../node-pty/prebuilds` already exists.
+  Nothing else would ever tell us #3250 shipped, and a plain `cp` would silently nest a
+  redundant `prebuilds/` inside upstream's.
+- **Corrected two comment claims**: the hash churn is driven by upstream *rewriting
+  package-lock.json* in its repair commit, not merely version-string churn; dropped the
+  unsupported "~10min" window; dated the v0.4.0 byte-identical claim rather than asserting
+  it open-endedly.
+- **Documented the ordering contract where it is actually edited** (`flake.nix`'s
+  `defaultOverlays`), because a misorder fails *silently*: an overlay placed before
+  `dotfilesOverlay` is plain-assigned over, dropping its packages out of `packages.*` and
+  `checks.*` with no eval error — which for paseo would disable the very stale-hash gate
+  this design exists to provide. Also corrected the `dotfilesOverlay` docstring, which
+  still claimed only `crates` extends the set.
+
+Deferred (not defects in this diff): CI has no binary cache and the npm-deps FOD alone is
+2.1GB with a 364MiB output closure, so every PR rebuilds paseo cold on `ubuntu-latest` —
+a plausible ENOSPC that would present as an unrelated failure. The spec's claim that the
+darwin build "stays evaluation-only" is also now wrong: `checks.aarch64-darwin.paseo` is a
+real build.
+
+## Deviations from the bean as written
+
+- The bean omits that `overlays/paseo.nix` must be `git add`-ed before Nix can see it —
+  the flake source is git-filtered, so Step 3 otherwise fails with
+  `Path 'overlays/paseo.nix' ... is not tracked by Git`, which looks nothing like the
+  `attribute 'paseo' missing` symptom the bean tells you to expect.
+- Step 4's premise did not hold: the placeholder hash (`sys-warbird`'s value) built clean
+  against this repo's `nixpkgs-darwin` 26.05, so no hash resolution was needed. Upstream's
+  v0.3.1 sidecar (`sha256-RCp5Og...`) does *not* match, so the override is still required.
+
+## Summary of Changes
+
+Added `overlays/paseo.nix` (new top-level `overlays/` directory) exposing a patched paseo
+at `pkgs.dotfiles.paseo`, and appended it to `defaultOverlays` in `flake.nix` after the
+`crates` entry.
+
+The overlay calls `final.callPackage "${inputs.paseo}/nix/package.nix"` with an explicit
+`npmDepsHash` — the supported route, since `buildNpmPackage` destructures that argument so
+`overrideAttrs` cannot reach it (upstream exposes it as a function argument for exactly
+this reason). It then `overrideAttrs` a `postInstall` copying node-pty's prebuilt binding
+into `$out`, which `scripts/trace-daemon.mjs` otherwise omits, breaking every terminal
+pane.
+
+Because `mkPackages = builtins.removeAttrs pkgs.dotfiles [ "internal" ]`, paseo now lands
+in both `packages.*` and `checks.*` — which is the point: `nix flake check` is the only
+thing that catches a stale `npmDepsHash` after a nixpkgs or paseo bump.
+
+### Verified
+
+- `nix eval --raw .#packages.{aarch64-darwin,x86_64-linux}.paseo.name` → `paseo-0.3.1`.
+- `nix build .#packages.aarch64-darwin.paseo` succeeds; the placeholder hash
+  (`sha256-oXz8hM...`, from `sys-warbird`) was already correct against this repo's
+  `nixpkgs-darwin` 26.05, so no hash resolution was needed. Upstream's v0.3.1 sidecar
+  (`sha256-RCp5Og...`) does not match, confirming the override is required.
+- The patch lands `prebuilds/darwin-arm64/{pty.node,spawn-helper}` with the exec bit
+  preserved, 140K instead of the whole 24MB tree; output closure 341MiB (was 364MiB).
+- The upstream-shipped-prebuilds guard was exercised in isolation across all three cases
+  (absent dir, no prebuilds, prebuilds present) — fires only in the last.
+- `nixfmt --check` clean; `nix flake check` → **all checks passed**.
+
+### Not verified locally
+
+`nix flake check` reports `omitted these incompatible systems: x86_64-linux`, so the linux
+build of paseo has *not* been built on this machine — only evaluated. CI's ubuntu runner
+is what proves it. Evidence it should work: upstream's `autoPatchelfHook` skips
+foreign-arch prebuilds, node-pty ships `linux-{x64,arm64}` in its published `files`, and
+both nixpkgs pins resolve `prefetch-npm-deps` to the identical source so one hash serves
+both.

--- a/flake.lock
+++ b/flake.lock
@@ -160,6 +160,27 @@
         "type": "github"
       }
     },
+    "paseo": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786275033,
+        "narHash": "sha256-m97Pf857LNv871b95cJ2y34OFxoES8JsWsp0wD3Em4I=",
+        "owner": "getpaseo",
+        "repo": "paseo",
+        "rev": "bfec7ac3adc5e8835e873ee75c7b325af6c7a8c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "getpaseo",
+        "ref": "v0.3.1",
+        "repo": "paseo",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "alacritty-themes": "alacritty-themes",
@@ -168,6 +189,7 @@
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
         "nixpkgs-darwin": "nixpkgs-darwin",
+        "paseo": "paseo",
         "rust-overlay": "rust-overlay"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -54,18 +54,26 @@
 
       # Discovers and builds the packages under ./packages. Plain assignment, not
       # a merge with `prev` — `dotfiles` deliberately shadows nixpkgs' own
-      # `dotfiles` attribute (a Python tool) with our package set. The `crates`
-      # overlay (applied after this one) extends the result with
-      # `internal.{rustToolchain,rustChecks}`, and `callPackage` auto-fills the
-      # `buildLocalRustBin` helper it exports for the package that declares it.
+      # `dotfiles` attribute (a Python tool) with our package set. Later overlays
+      # extend the result rather than replace it: `crates` adds
+      # `internal.{rustToolchain,rustChecks}` (and `callPackage` auto-fills the
+      # `buildLocalRustBin` helper it exports for the package that declares it),
+      # and `overlays/paseo.nix` adds `paseo`.
       dotfilesOverlay = final: _prev: {
         dotfiles = builtins.mapAttrs (_name: path: final.callPackage path { }) packagePaths;
       };
 
+      # Order matters and a misorder fails *silently*: both `crates` and
+      # `overlays/paseo.nix` extend the `dotfiles` set that `dotfilesOverlay`
+      # plain-assigns, so either one placed before it is quietly overwritten —
+      # dropping its packages out of `packages.*` and `checks.*` with no eval
+      # error. For paseo that would disable the only thing that catches a stale
+      # `npmDepsHash`. Keep `dotfilesOverlay` first.
       defaultOverlays = [
         inputs.alacritty-themes.overlays.default
         dotfilesOverlay
         (import ./crates { inherit inputs; })
+        (import ./overlays/paseo.nix { inherit inputs; })
       ];
 
       nixOsPkgs =

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,14 @@
     # crane is nixpkgs-agnostic (no `nixpkgs` input to follow); it reads pkgs
     # from `crane.mkLib pkgs` at call sites.
     crane.url = "github:ipetkov/crane";
+
+    # Self-hosted orchestrator for AI coding agents. Pinned to a tag: paseo's
+    # release tags ship a stale nix/npm-deps.hash, so overlays/paseo.nix has to
+    # supply a matching hash for whatever tag is pinned here. Bump both together.
+    paseo = {
+      url = "github:getpaseo/paseo/v0.3.1";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/overlays/paseo.nix
+++ b/overlays/paseo.nix
@@ -1,0 +1,68 @@
+# A nixpkgs overlay fragment (not a buildable package) exposing a patched paseo
+# as `pkgs.dotfiles.paseo`. Upstream does not build as tagged, so two patches
+# ride along. Both were re-verified against the pinned tag (v0.3.1) and v0.4.0
+# in 2026-08, whose `nix/package.nix` files were byte-identical at the time --
+# recheck rather than trust that on a bump. Neither patch has landed upstream.
+{ inputs }:
+final: prev:
+let
+  paseo =
+    (final.callPackage "${inputs.paseo}/nix/package.nix" {
+      # Every release tag ships a stale `nix/npm-deps.hash`. Two upstream
+      # mechanics combine: `fetchNpmDeps` copies package-lock.json verbatim into
+      # its fixed-output result, and the repair workflow that regenerates the
+      # hash triggers on push to main -- rewriting `package-lock.json` itself
+      # (its commit is "update lockfile signatures and Nix hash"), not just the
+      # version strings -- and only lands *after* the release commit is tagged.
+      # So a tag always points at the pre-repair state, and the mismatch can be
+      # larger than a version bump would suggest (holds for v0.2.5, v0.3.0,
+      # v0.3.1).
+      #
+      # Expect to re-point this at every bump rather than to drop it: take the
+      # `got:` hash from the failing build. Overriding is safe either way --
+      # package-lock.json's integrity fields pin the fetched contents
+      # independently of this hash.
+      #
+      # One hash, two consumers: `mkPackages` exposes this under both
+      # `inputs.nixpkgs` (x86_64-linux) and `inputs.nixpkgs-darwin`
+      # (aarch64-darwin), so the value must satisfy both. It does today because
+      # both pins resolve `prefetch-npm-deps` to the identical *source* over an
+      # identical filtered `src` -- that, not the nixpkgs revision, is the
+      # invariant. Verified by build on aarch64-darwin; x86_64-linux is gated by
+      # CI (`checks.x86_64-linux.paseo`), and the darwin half only by whoever
+      # runs `nix flake check` locally. If the two pins ever diverge, the `got:`
+      # hash from *your* platform is not necessarily the right one for both.
+      npmDepsHash = "sha256-oXz8hMk+5DlTYK8OndUAjB+RJMDbPqobVGXLFeoH++o=";
+    }).overrideAttrs
+      (old: {
+        # scripts/trace-daemon.mjs walks the JS module graph, so node-pty's
+        # prebuilt native binding never makes it into $out and every terminal
+        # pane reports "Terminal worker not running". Upstream PR #3250 copies
+        # the whole prebuilds/ tree; we copy only the host triple, because the
+        # runtime loader keys strictly on prebuilds/<platform>-<arch> (node-pty
+        # lib/utils.js) and the full tree is ~24MB of other platforms' binaries
+        # -- ~21MB of it win32 debug symbols -- to deliver ~140KB.
+        #
+        # The guard is the notification: nothing else will tell us when #3250
+        # (or a real trace fix) ships, and a plain `cp` would silently nest a
+        # redundant prebuilds/ inside upstream's once it does.
+        postInstall = (old.postInstall or "") + ''
+          ptyDest="$out/lib/paseo/packages/server/node_modules/node-pty"
+          if [ -e "$ptyDest/prebuilds" ]; then
+            echo "paseo: upstream now ships node-pty prebuilds; drop this patch" >&2
+            exit 1
+          fi
+          triple="$(node -p 'process.platform + "-" + process.arch')"
+          mkdir -p "$ptyDest/prebuilds/$triple"
+          cp -a "packages/server/node_modules/node-pty/prebuilds/$triple/." \
+            "$ptyDest/prebuilds/$triple/"
+        '';
+      });
+in
+{
+  # Extend (not clobber) the set `dotfilesOverlay` assigns. This overlay must
+  # come after it in `defaultOverlays`.
+  dotfiles = (prev.dotfiles or { }) // {
+    inherit paseo;
+  };
+}


### PR DESCRIPTION
Brings paseo into the flake as a patched package at `pkgs.dotfiles.paseo`, completing the
`paseo package wiring` feature (`dotfiles-pg0j`). This is the package half only — the
home-manager module (`dotfiles-ltuq`) and docs (`dotfiles-yk15`) are separate features.

Two commits, landed together deliberately: the input's comment references
`overlays/paseo.nix`, so splitting them would put a dangling reference and an
unreferenced input on `master`.

## `flake: add paseo input pinned to v0.3.1`

Pinned to a tag, following this repo's `nixpkgs` (which keeps a second `nixpkgs` node out
of `flake.lock`). Lock change is purely additive — one node at `bfec7ac3`, verified as the
`v0.3.1` tag commit; no existing input moved.

## `overlays: add patched paseo as pkgs.dotfiles.paseo`

New top-level `overlays/` directory for overlay fragments that aren't `packages/`-style
local derivations. Two upstream patches ride along, because paseo does not build as tagged:

1. **Stale `nix/npm-deps.hash` at every release tag.** Upstream's repair workflow triggers
   on push to main and rewrites `package-lock.json`, landing after the release commit is
   tagged — so a tag always points at the pre-repair state. Supplied via `callPackage`,
   which is the supported route: `buildNpmPackage` destructures `npmDepsHash`, so
   `overrideAttrs` cannot reach it.
2. **Missing `node-pty` prebuild in `$out`.** `scripts/trace-daemon.mjs` walks the JS
   module graph, so the native binding never gets installed and every terminal pane
   reports "Terminal worker not running".

Only the host triple's prebuilds are copied — 140K rather than the whole 24MB tree (~21MB
of which is win32 debug symbols) — since the runtime loader keys strictly on
`prebuilds/<platform>-<arch>`. That's a deliberate divergence from upstream PR #3250's
whole-tree `cp`, documented in the file. A guard fails the build if upstream ever ships
prebuilds itself, since nothing else would signal that this patch became redundant.

Landing at `pkgs.dotfiles.paseo` pulls paseo into `packages.*` and `checks.*` via
`mkPackages`, which is the point: `nix flake check` is the only thing that catches a stale
hash after a nixpkgs or paseo bump.

## Verification

- `nix eval` → `paseo-0.3.1` on both `aarch64-darwin` and `x86_64-linux`.
- `nix build .#packages.aarch64-darwin.paseo` succeeds; patch lands
  `prebuilds/darwin-arm64/{pty.node,spawn-helper}` with the exec bit preserved. Output
  closure 341MiB (was 364MiB before narrowing).
- `nix flake check` locally: **all checks passed**.

**What this PR itself is proving:** local `nix flake check` reports
`omitted these incompatible systems: x86_64-linux`, so the linux build of paseo has only
been *evaluated* here, never built. This CI run is the first real test of it — and of
whether a cold 2.1GB npm-deps fetch plus a 341MiB closure fits comfortably on
`ubuntu-latest` without a binary cache.

Follow-ups: dotfiles-egs1 (one `npmDepsHash` serves both the `nixpkgs` and
`nixpkgs-darwin` pins; measured as provably fine today, since both resolve
`prefetch-npm-deps` to the identical source)

🤖 Generated with [Claude Code](https://claude.com/claude-code)